### PR TITLE
[fe-20260325-213716] Implement ThemeProvider with per-user CSS custom properties

### DIFF
--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { Geist } from "next/font/google";
-import { cn } from "@whitelabel/ui";
+import { cn, ThemeProvider } from "@whitelabel/ui";
 
 const geist = Geist({subsets:['latin'],variable:'--font-sans'});
 
@@ -16,8 +16,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className={cn("font-sans", geist.variable)}>
-      <body>{children}</body>
+    <html lang="en" className={cn("font-sans", geist.variable)} suppressHydrationWarning>
+      <body>
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/packages/ui/src/components/theme-provider.tsx
+++ b/packages/ui/src/components/theme-provider.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type { ThemeConfig } from "../lib/theme-config";
+import {
+  applyThemeToDOM,
+  defaultLightTheme,
+  loadThemeFromStorage,
+  saveThemeToStorage,
+  themePresets,
+} from "../lib/theme-config";
+
+export interface ThemeContextValue {
+  /** The currently active theme config */
+  theme: ThemeConfig;
+  /** Set a new theme (applies immediately and persists to localStorage) */
+  setTheme: (theme: ThemeConfig) => void;
+  /** All available theme presets */
+  presets: ThemeConfig[];
+}
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+  /** Override the default theme (used on first load when no localStorage value exists) */
+  defaultTheme?: ThemeConfig;
+  /** Additional presets to include beyond the built-in ones */
+  extraPresets?: ThemeConfig[];
+}
+
+export function ThemeProvider({
+  children,
+  defaultTheme = defaultLightTheme,
+  extraPresets = [],
+}: ThemeProviderProps) {
+  const [theme, setThemeState] = useState<ThemeConfig>(defaultTheme);
+  const [mounted, setMounted] = useState(false);
+
+  // Load persisted theme on mount
+  useEffect(() => {
+    const stored = loadThemeFromStorage();
+    if (stored) {
+      setThemeState(stored);
+      applyThemeToDOM(stored);
+    } else {
+      applyThemeToDOM(defaultTheme);
+    }
+    setMounted(true);
+  }, [defaultTheme]);
+
+  const setTheme = useCallback((newTheme: ThemeConfig) => {
+    setThemeState(newTheme);
+    applyThemeToDOM(newTheme);
+    saveThemeToStorage(newTheme);
+  }, []);
+
+  const presets = useMemo(
+    () => [...themePresets, ...extraPresets],
+    [extraPresets],
+  );
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ theme, setTheme, presets }),
+    [theme, setTheme, presets],
+  );
+
+  // Prevent flash of unstyled content — render children only after mount
+  // so the correct CSS vars are in place. We still render the tree in SSR
+  // (via suppressHydrationWarning on <html>) but skip applying vars there.
+  return (
+    <ThemeContext.Provider value={value}>
+      {/* Always render children for SSR; CSS vars are applied in useEffect */}
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/packages/ui/src/hooks/use-theme.ts
+++ b/packages/ui/src/hooks/use-theme.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { useContext } from "react";
+import { ThemeContext } from "../components/theme-provider";
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,8 +1,21 @@
 // Utility
 export { cn } from "./lib/utils";
 
+// Theme
+export { ThemeProvider, ThemeContext } from "./components/theme-provider";
+export type { ThemeContextValue } from "./components/theme-provider";
+export {
+  defaultLightTheme,
+  defaultDarkTheme,
+  brandBlueTheme,
+  brandGreenTheme,
+  themePresets,
+} from "./lib/theme-config";
+export type { ThemeConfig } from "./lib/theme-config";
+
 // Hooks
 export { useIsMobile } from "./hooks/use-mobile";
+export { useTheme } from "./hooks/use-theme";
 
 // Components
 export * from "./components/ui/accordion";

--- a/packages/ui/src/lib/theme-config.ts
+++ b/packages/ui/src/lib/theme-config.ts
@@ -1,0 +1,151 @@
+export interface ThemeConfig {
+  name: string;
+  colors: {
+    background: string;
+    foreground: string;
+    primary: string;
+    primaryForeground: string;
+    secondary: string;
+    secondaryForeground: string;
+    muted: string;
+    mutedForeground: string;
+    accent: string;
+    accentForeground: string;
+    destructive: string;
+    border: string;
+    ring: string;
+  };
+  radius: string;
+  fontFamily?: string;
+}
+
+export const defaultLightTheme: ThemeConfig = {
+  name: "default-light",
+  colors: {
+    background: "oklch(1 0 0)",
+    foreground: "oklch(0.145 0 0)",
+    primary: "oklch(0.205 0 0)",
+    primaryForeground: "oklch(0.985 0 0)",
+    secondary: "oklch(0.97 0 0)",
+    secondaryForeground: "oklch(0.205 0 0)",
+    muted: "oklch(0.97 0 0)",
+    mutedForeground: "oklch(0.556 0 0)",
+    accent: "oklch(0.97 0 0)",
+    accentForeground: "oklch(0.205 0 0)",
+    destructive: "oklch(0.577 0.245 27.325)",
+    border: "oklch(0.922 0 0)",
+    ring: "oklch(0.708 0 0)",
+  },
+  radius: "0.625rem",
+};
+
+export const defaultDarkTheme: ThemeConfig = {
+  name: "default-dark",
+  colors: {
+    background: "oklch(0.145 0 0)",
+    foreground: "oklch(0.985 0 0)",
+    primary: "oklch(0.922 0 0)",
+    primaryForeground: "oklch(0.205 0 0)",
+    secondary: "oklch(0.269 0 0)",
+    secondaryForeground: "oklch(0.985 0 0)",
+    muted: "oklch(0.269 0 0)",
+    mutedForeground: "oklch(0.708 0 0)",
+    accent: "oklch(0.269 0 0)",
+    accentForeground: "oklch(0.985 0 0)",
+    destructive: "oklch(0.704 0.191 22.216)",
+    border: "oklch(1 0 0 / 10%)",
+    ring: "oklch(0.556 0 0)",
+  },
+  radius: "0.625rem",
+};
+
+export const brandBlueTheme: ThemeConfig = {
+  name: "brand-blue",
+  colors: {
+    background: "oklch(0.985 0.002 250)",
+    foreground: "oklch(0.145 0.02 250)",
+    primary: "oklch(0.488 0.243 264.376)",
+    primaryForeground: "oklch(0.985 0 0)",
+    secondary: "oklch(0.94 0.02 250)",
+    secondaryForeground: "oklch(0.205 0.02 250)",
+    muted: "oklch(0.94 0.015 250)",
+    mutedForeground: "oklch(0.556 0.02 250)",
+    accent: "oklch(0.92 0.03 250)",
+    accentForeground: "oklch(0.205 0.02 250)",
+    destructive: "oklch(0.577 0.245 27.325)",
+    border: "oklch(0.9 0.02 250)",
+    ring: "oklch(0.488 0.243 264.376)",
+  },
+  radius: "0.75rem",
+};
+
+export const brandGreenTheme: ThemeConfig = {
+  name: "brand-green",
+  colors: {
+    background: "oklch(0.985 0.005 155)",
+    foreground: "oklch(0.145 0.02 155)",
+    primary: "oklch(0.55 0.18 155)",
+    primaryForeground: "oklch(0.985 0 0)",
+    secondary: "oklch(0.94 0.02 155)",
+    secondaryForeground: "oklch(0.205 0.02 155)",
+    muted: "oklch(0.94 0.015 155)",
+    mutedForeground: "oklch(0.556 0.02 155)",
+    accent: "oklch(0.92 0.03 155)",
+    accentForeground: "oklch(0.205 0.02 155)",
+    destructive: "oklch(0.577 0.245 27.325)",
+    border: "oklch(0.9 0.02 155)",
+    ring: "oklch(0.55 0.18 155)",
+  },
+  radius: "0.5rem",
+};
+
+export const themePresets: ThemeConfig[] = [
+  defaultLightTheme,
+  defaultDarkTheme,
+  brandBlueTheme,
+  brandGreenTheme,
+];
+
+const STORAGE_KEY = "whitelabel-theme";
+
+export function loadThemeFromStorage(): ThemeConfig | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as ThemeConfig;
+  } catch {
+    return null;
+  }
+}
+
+export function saveThemeToStorage(theme: ThemeConfig): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(theme));
+  } catch {
+    // Storage full or unavailable — silently ignore
+  }
+}
+
+export function applyThemeToDOM(theme: ThemeConfig): void {
+  const root = document.documentElement;
+  root.style.setProperty("--background", theme.colors.background);
+  root.style.setProperty("--foreground", theme.colors.foreground);
+  root.style.setProperty("--primary", theme.colors.primary);
+  root.style.setProperty("--primary-foreground", theme.colors.primaryForeground);
+  root.style.setProperty("--secondary", theme.colors.secondary);
+  root.style.setProperty("--secondary-foreground", theme.colors.secondaryForeground);
+  root.style.setProperty("--muted", theme.colors.muted);
+  root.style.setProperty("--muted-foreground", theme.colors.mutedForeground);
+  root.style.setProperty("--accent", theme.colors.accent);
+  root.style.setProperty("--accent-foreground", theme.colors.accentForeground);
+  root.style.setProperty("--destructive", theme.colors.destructive);
+  root.style.setProperty("--border", theme.colors.border);
+  root.style.setProperty("--ring", theme.colors.ring);
+  root.style.setProperty("--radius", theme.radius);
+  if (theme.fontFamily) {
+    root.style.setProperty("--font-sans", theme.fontFamily);
+  }
+  root.setAttribute("data-theme", theme.name);
+}


### PR DESCRIPTION
Closes #3

Implemented by agent `fe-20260325-213716`.

## Changes
- `packages/ui/src/lib/theme-config.ts` — ThemeConfig type, 4 presets (default-light, default-dark, brand-blue, brand-green), localStorage persistence helpers, DOM application
- `packages/ui/src/components/theme-provider.tsx` — ThemeProvider context component
- `packages/ui/src/hooks/use-theme.ts` — useTheme() hook
- `packages/ui/src/index.ts` — exports for all new modules
- `apps/dashboard/src/app/layout.tsx` — root layout wrapped with ThemeProvider