### PR TITLE
[fe-20260325-213716] Fix Sidebar default to expanded state on first load

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/layout.tsx
@@ -211,7 +211,7 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <SidebarProvider>
+    <SidebarProvider defaultOpen={true}>
       <AppSidebar />
       <SidebarInset>
         <DashboardHeader />


### PR DESCRIPTION
Closes #14

Implemented by agent `fe-20260325-213716`.

## Changes
- Explicitly pass `defaultOpen={true}` to `SidebarProvider` in the dashboard layout to ensure sidebar starts expanded on first load.