### PR TITLE
[fe-20260325-213716] Add border/shadow to dashboard cards and content blocks

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/page.tsx
@@ -67,7 +67,7 @@ function StatCard({
   icon: React.ReactNode;
 }) {
   return (
-    <Card className="bg-muted/30">
+    <Card className="shadow-sm ring-1 ring-border/50">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-xs font-medium uppercase tracking-widest text-muted-foreground font-mono">
           {label}

--- a/apps/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -30,12 +30,12 @@ export default function SettingsPage() {
           <ThemeCustomizer />
         </TabsContent>
         <TabsContent value="account" className="mt-6">
-          <div className="rounded-xl bg-muted/30 p-6 text-muted-foreground ring-1 ring-foreground/10">
+          <div className="rounded-xl p-6 text-muted-foreground shadow-sm ring-1 ring-border/50">
             Account settings will go here.
           </div>
         </TabsContent>
         <TabsContent value="notifications" className="mt-6">
-          <div className="rounded-xl bg-muted/30 p-6 text-muted-foreground ring-1 ring-foreground/10">
+          <div className="rounded-xl p-6 text-muted-foreground shadow-sm ring-1 ring-border/50">
             Notification preferences will go here.
           </div>
         </TabsContent>


### PR DESCRIPTION
Closes #15

Implemented by agent `fe-20260325-213716`.

## Changes
- Stat cards: replaced `bg-muted/30` with `shadow-sm ring-1 ring-border/50` for clear visual hierarchy
- Settings placeholder blocks: updated with matching `shadow-sm ring-1 ring-border/50`
- Uses existing `--border` design token for consistency