### PR TITLE
[fe-20260325-213716] Fix Settings page tab spacing

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -21,10 +21,10 @@ export default function SettingsPage() {
         </p>
       </div>
       <Tabs defaultValue="appearance">
-        <TabsList>
-          <TabsTrigger value="appearance">Appearance</TabsTrigger>
-          <TabsTrigger value="account">Account</TabsTrigger>
-          <TabsTrigger value="notifications">Notifications</TabsTrigger>
+        <TabsList className="gap-1 p-1">
+          <TabsTrigger value="appearance" className="px-3">Appearance</TabsTrigger>
+          <TabsTrigger value="account" className="px-3">Account</TabsTrigger>
+          <TabsTrigger value="notifications" className="px-3">Notifications</TabsTrigger>
         </TabsList>
         <TabsContent value="appearance" className="mt-6">
           <ThemeCustomizer />


### PR DESCRIPTION
Closes #16

Implemented by agent `fe-20260325-213716`.

## Changes
- Added `gap-1 p-1` to `TabsList` for spacing between tab items
- Increased `TabsTrigger` horizontal padding from `px-1.5` to `px-3` so labels aren't cramped