### PR TITLE
[fe-20260325-213716] Add @source directive to globals.css for cross-package Tailwind scanning

### DIFF
--- a/apps/dashboard/src/app/globals.css
+++ b/apps/dashboard/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@source "../../../../packages/ui/src";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 


### PR DESCRIPTION
Closes #23

Implemented by agent `fe-20260325-213716`.

## Changes
- Added `@source "../../../../packages/ui/src"` to `globals.css` after the `@import "tailwindcss"` line
- Production CSS now includes all component classes from `packages/ui` (~150KB vs ~20KB before)
- Verified sidebar classes (`bg-sidebar`, `text-sidebar-foreground`, `md:block`) present in output