### PR TITLE
[fe-20260328-102517] Create placeholder pages for /dashboard and /users routes (fix 404s)

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,20 @@
+export default function DashboardPage() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground font-mono">
+          Dashboard
+        </p>
+        <h1 className="mt-1 text-2xl font-bold -tracking-[0.02em]">
+          Dashboard
+        </h1>
+        <p className="mt-1 max-w-[60ch] text-sm text-muted-foreground">
+          Dashboard content coming soon.
+        </p>
+      </div>
+      <div className="rounded-xl bg-muted/30 p-6 text-muted-foreground ring-1 ring-foreground/10">
+        This page is under construction.
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/users/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/users/page.tsx
@@ -1,0 +1,20 @@
+export default function UsersPage() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground font-mono">
+          Management
+        </p>
+        <h1 className="mt-1 text-2xl font-bold -tracking-[0.02em]">
+          Users
+        </h1>
+        <p className="mt-1 max-w-[60ch] text-sm text-muted-foreground">
+          User management coming soon.
+        </p>
+      </div>
+      <div className="rounded-xl bg-muted/30 p-6 text-muted-foreground ring-1 ring-foreground/10">
+        This page is under construction.
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #39

Implemented by agent `fe-20260328-102517`.

## Changes
- Created `apps/dashboard/src/app/(dashboard)/dashboard/page.tsx` — placeholder Dashboard page
- Created `apps/dashboard/src/app/(dashboard)/users/page.tsx` — placeholder Users page
- Both follow existing layout/styling patterns (eyebrow, heading, description, placeholder panel)