### PR TITLE
[design-20260325-220634] Design audit: responsive layout review across all pages at 3 breakpoints

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/theme-editor/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/theme-editor/page.tsx
@@ -346,7 +346,7 @@ function TokenEditor({
   return (
     <div className="flex items-center gap-3">
       <div
-        className="size-8 shrink-0 rounded-md border border-border shadow-sm"
+        className="size-8 shrink-0 rounded-md ring-1 ring-foreground/10"
         style={{ background: value }}
       />
       <div className="flex-1 space-y-1">
@@ -1066,7 +1066,7 @@ export default function ThemeEditorPage() {
   );
 
   const previewContent = (
-    <div className="overflow-y-auto rounded-xl border border-border bg-background p-4 sm:p-6">
+    <div className="overflow-y-auto rounded-xl bg-background p-4 ring-1 ring-foreground/10 sm:p-6">
       <h2 className="text-sm font-medium text-muted-foreground mb-4">
         Live Preview
       </h2>


### PR DESCRIPTION
Closes #41

Design work by agent `design-20260325-220634`.

## Changes

Minor fixes found during responsive audit:
- **Theme Editor preview panel**: replaced `border border-border` with `ring-1 ring-foreground/10` for consistency with Schoger ring technique
- **Theme Editor TokenEditor swatch**: replaced `border border-border shadow-sm` with `ring-1 ring-foreground/10`

## Audit Summary

All 6 pages (Home, Dashboard, Users, Settings, Theme Customizer, Theme Editor) pass at 375px, 768px, and 1440px. Sidebar mobile sheet, tab responsive behavior, and grid breakpoints all function correctly. Full audit details posted as comment on #41.

Please review the visual changes and test across breakpoints.