### PR TITLE
[fe-20260328-102517] Theme Editor: add Typography tab (font family selection + letter spacing)

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/theme-editor/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/theme-editor/page.tsx
@@ -710,6 +710,9 @@ export default function ThemeEditorPage() {
   // Mobile/tablet: tab-based view (editor vs preview)
   const [mobileTab, setMobileTab] = useState<"editor" | "preview">("editor");
 
+  // Editor sub-tab: colors vs typography
+  const [editorTab, setEditorTab] = useState<"colors" | "typography">("colors");
+
   // Custom themes state
   const [customThemes, setCustomThemes] = useState<ThemeConfig[]>([]);
 
@@ -780,6 +783,24 @@ export default function ThemeEditorPage() {
       applyDraft({ ...draft, radius: `${v}rem` });
     },
     [draft, applyDraft]
+  );
+
+  const updateTypography = useCallback(
+    (key: keyof NonNullable<ThemeConfig["typography"]>, value: string) => {
+      applyDraft({
+        ...draft,
+        typography: { ...draft.typography, [key]: value },
+      });
+    },
+    [draft, applyDraft]
+  );
+
+  const handleLetterSpacingChange = useCallback(
+    (val: number | readonly number[]) => {
+      const v = Array.isArray(val) ? val[0] : val;
+      updateTypography("letterSpacing", `${v}em`);
+    },
+    [updateTypography]
   );
 
   // --- Save theme ---
@@ -1046,22 +1067,135 @@ export default function ThemeEditorPage() {
         </div>
       </section>
 
-      {/* Token groups */}
-      {TOKEN_GROUPS.map((group) => (
-        <section key={group.label} className="space-y-3">
-          <h2 className="text-sm font-medium">{group.label}</h2>
-          <div className="space-y-2">
-            {group.tokens.map((t) => (
-              <TokenEditor
-                key={t.key}
-                label={t.label}
-                value={draft.colors[t.key]}
-                onChange={(v) => updateColor(t.key, v)}
+      {/* Editor sub-tabs: Colors / Typography */}
+      <div className="flex gap-1 border-b border-border pb-1">
+        <button
+          onClick={() => setEditorTab("colors")}
+          className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+            editorTab === "colors"
+              ? "bg-secondary text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          Colors
+        </button>
+        <button
+          onClick={() => setEditorTab("typography")}
+          className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+            editorTab === "typography"
+              ? "bg-secondary text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          Typography
+        </button>
+      </div>
+
+      {editorTab === "colors" && (
+        <>
+          {/* Token groups */}
+          {TOKEN_GROUPS.map((group) => (
+            <section key={group.label} className="space-y-3">
+              <h2 className="text-sm font-medium">{group.label}</h2>
+              <div className="space-y-2">
+                {group.tokens.map((t) => (
+                  <TokenEditor
+                    key={t.key}
+                    label={t.label}
+                    value={draft.colors[t.key]}
+                    onChange={(v) => updateColor(t.key, v)}
+                  />
+                ))}
+              </div>
+            </section>
+          ))}
+        </>
+      )}
+
+      {editorTab === "typography" && (
+        <>
+          {/* Font Family: Sans */}
+          <section className="space-y-3">
+            <h2 className="text-sm font-medium">Sans-Serif Font</h2>
+            <Select
+              value={draft.typography?.fontSans || ""}
+              onValueChange={(v) => v && updateTypography("fontSans", v)}
+            >
+              <SelectTrigger className="text-sm">
+                <SelectValue placeholder="Default (Geist)" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Geist, sans-serif">Geist</SelectItem>
+                <SelectItem value="Inter, sans-serif">Inter</SelectItem>
+                <SelectItem value="system-ui, sans-serif">System UI</SelectItem>
+                <SelectItem value="'Helvetica Neue', Helvetica, sans-serif">Helvetica Neue</SelectItem>
+                <SelectItem value="'Segoe UI', sans-serif">Segoe UI</SelectItem>
+                <SelectItem value="Roboto, sans-serif">Roboto</SelectItem>
+              </SelectContent>
+            </Select>
+          </section>
+
+          {/* Font Family: Serif */}
+          <section className="space-y-3">
+            <h2 className="text-sm font-medium">Serif Font</h2>
+            <Select
+              value={draft.typography?.fontSerif || ""}
+              onValueChange={(v) => v && updateTypography("fontSerif", v)}
+            >
+              <SelectTrigger className="text-sm">
+                <SelectValue placeholder="Default (serif)" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Georgia, serif">Georgia</SelectItem>
+                <SelectItem value="'Times New Roman', serif">Times New Roman</SelectItem>
+                <SelectItem value="'Palatino Linotype', serif">Palatino</SelectItem>
+                <SelectItem value="Cambria, serif">Cambria</SelectItem>
+              </SelectContent>
+            </Select>
+          </section>
+
+          {/* Font Family: Mono */}
+          <section className="space-y-3">
+            <h2 className="text-sm font-medium">Monospace Font</h2>
+            <Select
+              value={draft.typography?.fontMono || ""}
+              onValueChange={(v) => v && updateTypography("fontMono", v)}
+            >
+              <SelectTrigger className="text-sm">
+                <SelectValue placeholder="Default (monospace)" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="'Geist Mono', monospace">Geist Mono</SelectItem>
+                <SelectItem value="'JetBrains Mono', monospace">JetBrains Mono</SelectItem>
+                <SelectItem value="'Fira Code', monospace">Fira Code</SelectItem>
+                <SelectItem value="'SF Mono', monospace">SF Mono</SelectItem>
+                <SelectItem value="Menlo, monospace">Menlo</SelectItem>
+                <SelectItem value="'Courier New', monospace">Courier New</SelectItem>
+              </SelectContent>
+            </Select>
+          </section>
+
+          {/* Letter Spacing */}
+          <section className="space-y-3">
+            <h2 className="text-sm font-medium">Letter Spacing</h2>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label className="text-xs">Tracking</Label>
+                <span className="text-xs text-muted-foreground font-mono">
+                  {(parseFloat(draft.typography?.letterSpacing || "0") || 0).toFixed(3)}em
+                </span>
+              </div>
+              <Slider
+                value={[parseFloat(draft.typography?.letterSpacing || "0") || 0]}
+                min={0}
+                max={0.2}
+                step={0.005}
+                onValueChange={handleLetterSpacingChange}
               />
-            ))}
-          </div>
-        </section>
-      ))}
+            </div>
+          </section>
+        </>
+      )}
     </div>
   );
 

--- a/packages/ui/src/lib/theme-config.ts
+++ b/packages/ui/src/lib/theme-config.ts
@@ -57,6 +57,12 @@ export interface ThemeConfig {
   };
   radius: string;
   fontFamily?: string;
+  typography?: {
+    fontSans?: string;
+    fontSerif?: string;
+    fontMono?: string;
+    letterSpacing?: string;
+  };
 }
 
 export const defaultLightTheme: ThemeConfig = {
@@ -381,6 +387,20 @@ export function applyThemeToDOM(theme: ThemeConfig): void {
   root.style.setProperty("--radius", theme.radius);
   if (theme.fontFamily) {
     root.style.setProperty("--font-sans", theme.fontFamily);
+  }
+  if (theme.typography) {
+    if (theme.typography.fontSans) {
+      root.style.setProperty("--font-sans", theme.typography.fontSans);
+    }
+    if (theme.typography.fontSerif) {
+      root.style.setProperty("--font-serif", theme.typography.fontSerif);
+    }
+    if (theme.typography.fontMono) {
+      root.style.setProperty("--font-mono", theme.typography.fontMono);
+    }
+    if (theme.typography.letterSpacing) {
+      root.style.setProperty("--tracking-body", theme.typography.letterSpacing);
+    }
   }
   root.setAttribute("data-theme", theme.name);
 }


### PR DESCRIPTION
Closes #46

Implemented by agent `fe-20260328-102517`.

## Changes
- Extended `ThemeConfig` type with optional `typography` object (fontSans, fontSerif, fontMono, letterSpacing)
- Updated `applyThemeToDOM()` to set `--font-sans`, `--font-serif`, `--font-mono`, `--tracking-body` CSS variables
- Added Colors/Typography sub-tab switcher in the Theme Editor left panel
- Typography tab has Select dropdowns for sans-serif, serif, and monospace fonts with common system/web font options
- Letter spacing slider (0 to 0.2em) for tracking adjustment
- All typography settings persist to localStorage via ThemeConfig