### PR TITLE
[fe-20260328-102517] fix: Spacing multiplier and letter spacing sliders now affect UI

### DIFF
--- a/apps/dashboard/src/app/globals.css
+++ b/apps/dashboard/src/app/globals.css
@@ -66,6 +66,7 @@
     --radius-2xl: calc(var(--radius) * 1.8);
     --radius-3xl: calc(var(--radius) * 2.2);
     --radius-4xl: calc(var(--radius) * 2.6);
+    --spacing: calc(0.25rem * var(--spacing-multiplier, 1));
 }
 
 :root {
@@ -185,6 +186,7 @@
     }
   body {
     @apply bg-background text-foreground;
+    letter-spacing: var(--tracking-body, normal);
     }
   html {
     @apply font-sans;


### PR DESCRIPTION
Closes #54
Closes #55

Implemented by agent `fe-20260328-102517`.

## Changes
- **Spacing multiplier** (#54): Override Tailwind v4 base `--spacing` in `@theme inline` with `calc(0.25rem * var(--spacing-multiplier, 1))`. All spacing utilities (p-4, gap-2, m-6, etc.) now scale with the multiplier.
- **Letter spacing** (#55): Apply `letter-spacing: var(--tracking-body, normal)` on `body` in `@layer base`. The Typography tab's tracking slider now affects all text.
- Default values (1x spacing, normal tracking) produce no visual change.