### PR TITLE
[fe-20260328-102517] Theme Editor: multi-scene preview tabs (Components, Cards, Dashboard)

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/theme-editor/cards-scene.tsx
+++ b/apps/dashboard/src/app/(dashboard)/theme-editor/cards-scene.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import {
+  Avatar,
+  AvatarFallback,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Checkbox,
+  Input,
+  Label,
+  Separator,
+  Switch,
+} from "@whitelabel/ui";
+import { LockIcon, MailIcon, UsersIcon } from "lucide-react";
+
+export function CardsScene() {
+  return (
+    <div className="grid gap-6 sm:grid-cols-2">
+      {/* Login Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Login</CardTitle>
+          <CardDescription>Sign in to your account</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label className="text-sm">Email</Label>
+            <div className="relative">
+              <MailIcon className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+              <Input placeholder="you@example.com" className="pl-8" />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm">Password</Label>
+            <div className="relative">
+              <LockIcon className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+              <Input type="password" placeholder="••••••••" className="pl-8" />
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox />
+            <Label className="text-sm">Remember me</Label>
+          </div>
+        </CardContent>
+        <CardFooter>
+          <Button className="w-full">Sign In</Button>
+        </CardFooter>
+      </Card>
+
+      {/* Team Members Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <UsersIcon className="size-4" />
+            Team Members
+          </CardTitle>
+          <CardDescription>Manage your team</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {[
+            { name: "Alice Chen", role: "Admin", initials: "AC" },
+            { name: "Bob Smith", role: "Editor", initials: "BS" },
+            { name: "Carol Lee", role: "Viewer", initials: "CL" },
+          ].map((member) => (
+            <div key={member.name} className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <Avatar className="size-8">
+                  <AvatarFallback className="text-xs">{member.initials}</AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="text-sm font-medium">{member.name}</p>
+                  <p className="text-xs text-muted-foreground">{member.role}</p>
+                </div>
+              </div>
+              <Button variant="outline" size="sm">Edit</Button>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* Cookie Settings Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Cookie Settings</CardTitle>
+          <CardDescription>Manage your cookie preferences</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {[
+            { label: "Strictly Necessary", desc: "Required for the site to function", locked: true },
+            { label: "Functional", desc: "Enable enhanced functionality", locked: false },
+            { label: "Analytics", desc: "Help us improve our site", locked: false },
+          ].map((cookie) => (
+            <div key={cookie.label} className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label className="text-sm">{cookie.label}</Label>
+                <p className="text-xs text-muted-foreground">{cookie.desc}</p>
+              </div>
+              <Switch defaultChecked={cookie.locked} disabled={cookie.locked} />
+            </div>
+          ))}
+        </CardContent>
+        <CardFooter className="flex gap-2">
+          <Button variant="outline" className="flex-1">Decline All</Button>
+          <Button className="flex-1">Accept All</Button>
+        </CardFooter>
+      </Card>
+
+      {/* Notification Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Notifications</CardTitle>
+          <CardDescription>Recent activity</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {[
+            { text: "New user registered", time: "2 min ago", dot: "bg-primary" },
+            { text: "Payment received", time: "1 hour ago", dot: "bg-primary/60" },
+            { text: "Server alert cleared", time: "3 hours ago", dot: "bg-muted-foreground/40" },
+          ].map((item, i) => (
+            <div key={i}>
+              <div className="flex items-start gap-3">
+                <div className={`mt-1.5 size-2 shrink-0 rounded-full ${item.dot}`} />
+                <div className="flex-1">
+                  <p className="text-sm">{item.text}</p>
+                  <p className="text-xs text-muted-foreground">{item.time}</p>
+                </div>
+              </div>
+              {i < 2 && <Separator className="mt-3" />}
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/theme-editor/dashboard-scene.tsx
+++ b/apps/dashboard/src/app/(dashboard)/theme-editor/dashboard-scene.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Progress,
+  Separator,
+} from "@whitelabel/ui";
+import {
+  ActivityIcon,
+  ArrowUpIcon,
+  ArrowDownIcon,
+  DollarSignIcon,
+  ShoppingCartIcon,
+  UsersIcon,
+} from "lucide-react";
+
+function MiniKPI({
+  label,
+  value,
+  change,
+  trend,
+  icon,
+}: {
+  label: string;
+  value: string;
+  change: string;
+  trend: "up" | "down";
+  icon: React.ReactNode;
+}) {
+  return (
+    <Card className="bg-muted/30">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-xs font-medium uppercase tracking-widest text-muted-foreground font-mono">
+          {label}
+        </CardTitle>
+        {icon}
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold -tracking-[0.02em]">{value}</div>
+        <p className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
+          {trend === "up" ? (
+            <ArrowUpIcon className="size-3 text-primary" />
+          ) : (
+            <ArrowDownIcon className="size-3 text-destructive" />
+          )}
+          {change}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function DashboardScene() {
+  return (
+    <div className="space-y-6">
+      {/* Mini sidebar + header mockup */}
+      <div className="flex gap-4">
+        <div className="hidden sm:flex w-12 shrink-0 flex-col gap-2 rounded-lg bg-muted/30 p-2 ring-1 ring-foreground/10">
+          {[1, 2, 3, 4].map((i) => (
+            <div
+              key={i}
+              className={`h-8 w-full rounded-md ${i === 1 ? "bg-primary/20" : "bg-muted/50"}`}
+            />
+          ))}
+        </div>
+        <div className="flex-1 space-y-4">
+          {/* Header bar */}
+          <div className="flex items-center justify-between rounded-lg bg-muted/20 px-4 py-2 ring-1 ring-foreground/10">
+            <span className="text-sm font-medium">Dashboard</span>
+            <div className="flex items-center gap-2">
+              <Badge variant="secondary">Live</Badge>
+              <Button variant="outline" size="sm">Export</Button>
+            </div>
+          </div>
+
+          {/* KPI Grid */}
+          <div className="grid gap-3 grid-cols-2 lg:grid-cols-4">
+            <MiniKPI
+              label="Revenue"
+              value="$45.2k"
+              change="+12.5%"
+              trend="up"
+              icon={<DollarSignIcon className="size-4 text-muted-foreground" />}
+            />
+            <MiniKPI
+              label="Orders"
+              value="1,234"
+              change="+8.2%"
+              trend="up"
+              icon={<ShoppingCartIcon className="size-4 text-muted-foreground" />}
+            />
+            <MiniKPI
+              label="Users"
+              value="5,678"
+              change="-2.1%"
+              trend="down"
+              icon={<UsersIcon className="size-4 text-muted-foreground" />}
+            />
+            <MiniKPI
+              label="Active"
+              value="892"
+              change="+4.3%"
+              trend="up"
+              icon={<ActivityIcon className="size-4 text-muted-foreground" />}
+            />
+          </div>
+
+          {/* Chart placeholder + Recent activity */}
+          <div className="grid gap-4 sm:grid-cols-2">
+            {/* Chart area */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-sm">Revenue Overview</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-end gap-1 h-32">
+                  {[40, 65, 45, 80, 55, 90, 70, 85, 60, 95, 75, 88].map((h, i) => (
+                    <div
+                      key={i}
+                      className="flex-1 rounded-t bg-primary/20"
+                      style={{ height: `${h}%` }}
+                    />
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Activity */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-sm">Recent Activity</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {[
+                  { label: "New signups", value: 42, max: 100 },
+                  { label: "Active sessions", value: 78, max: 100 },
+                  { label: "Conversion", value: 23, max: 100 },
+                  { label: "Retention", value: 65, max: 100 },
+                ].map((item) => (
+                  <div key={item.label} className="space-y-1.5">
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="text-muted-foreground">{item.label}</span>
+                      <span className="font-mono">{item.value}%</span>
+                    </div>
+                    <Progress value={item.value} />
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+
+      <Separator />
+
+      {/* Table mockup */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Recent Orders</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            <div className="grid grid-cols-4 text-xs font-medium text-muted-foreground pb-2 border-b border-border">
+              <span>Order</span>
+              <span>Customer</span>
+              <span>Status</span>
+              <span className="text-right">Amount</span>
+            </div>
+            {[
+              { id: "#3210", customer: "Alice Chen", status: "Completed", amount: "$250.00" },
+              { id: "#3209", customer: "Bob Smith", status: "Processing", amount: "$150.00" },
+              { id: "#3208", customer: "Carol Lee", status: "Pending", amount: "$350.00" },
+            ].map((order) => (
+              <div key={order.id} className="grid grid-cols-4 text-sm py-2">
+                <span className="font-mono text-xs">{order.id}</span>
+                <span>{order.customer}</span>
+                <span>
+                  <Badge
+                    variant={
+                      order.status === "Completed" ? "default" :
+                      order.status === "Processing" ? "secondary" : "outline"
+                    }
+                  >
+                    {order.status}
+                  </Badge>
+                </span>
+                <span className="text-right font-mono text-xs">{order.amount}</span>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/theme-editor/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/theme-editor/page.tsx
@@ -92,6 +92,8 @@ import {
   Trash2Icon,
   UnderlineIcon,
 } from "lucide-react";
+import { CardsScene } from "./cards-scene";
+import { DashboardScene } from "./dashboard-scene";
 
 // ---------------------------------------------------------------------------
 // Token groups: only the ~20 primary tokens users should edit directly
@@ -1359,10 +1361,27 @@ export default function ThemeEditorPage() {
 
   const previewContent = (
     <div className="overflow-y-auto rounded-xl bg-background p-4 ring-1 ring-foreground/10 sm:p-6">
-      <h2 className="text-sm font-medium text-muted-foreground mb-4">
-        Live Preview
-      </h2>
-      <LivePreview />
+      <Tabs defaultValue="components">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-sm font-medium text-muted-foreground">
+            Live Preview
+          </h2>
+          <TabsList className="gap-1 p-1">
+            <TabsTrigger value="components" className="px-2.5 text-xs">Components</TabsTrigger>
+            <TabsTrigger value="cards" className="px-2.5 text-xs">Cards</TabsTrigger>
+            <TabsTrigger value="dashboard" className="px-2.5 text-xs">Dashboard</TabsTrigger>
+          </TabsList>
+        </div>
+        <TabsContent value="components" className="mt-0">
+          <LivePreview />
+        </TabsContent>
+        <TabsContent value="cards" className="mt-0">
+          <CardsScene />
+        </TabsContent>
+        <TabsContent value="dashboard" className="mt-0">
+          <DashboardScene />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 


### PR DESCRIPTION
Closes #48

Implemented by agent `fe-20260328-102517`.

## Changes
- Replaced single LivePreview with tabbed multi-scene preview using shadcn/ui Tabs
- **Components tab**: Existing component showcase (kept as-is)
- **Cards tab** (`cards-scene.tsx`): Login form, team members list, cookie settings, notifications
- **Dashboard tab** (`dashboard-scene.tsx`): Mini sidebar mockup, 4 KPI cards, bar chart, activity progress bars, orders table with badges
- Each scene is a separate component file for maintainability
- Tab switcher positioned inline with "Live Preview" heading