### PR TITLE
[be-20260325-010103] Restructure ThemeConfig for light/dark dual mode + header toggle

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/layout.tsx
@@ -32,15 +32,18 @@ import {
   SidebarProvider,
   SidebarRail,
   SidebarTrigger,
+  useTheme,
 } from "@whitelabel/ui";
 import {
   BellIcon,
   HomeIcon,
   LayoutDashboardIcon,
   LogOutIcon,
+  MoonIcon,
   PaletteIcon,
   SearchIcon,
   SettingsIcon,
+  SunIcon,
   UserIcon,
   UsersIcon,
 } from "lucide-react";
@@ -159,6 +162,20 @@ function DashboardBreadcrumb() {
   );
 }
 
+function ColorModeToggle() {
+  const { colorMode, toggleColorMode } = useTheme();
+  return (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      aria-label={colorMode === "light" ? "Switch to dark mode" : "Switch to light mode"}
+      onClick={toggleColorMode}
+    >
+      {colorMode === "light" ? <MoonIcon className="size-4" /> : <SunIcon className="size-4" />}
+    </Button>
+  );
+}
+
 function DashboardHeader() {
   return (
     <header className="flex h-14 shrink-0 items-center gap-2 px-4 ring-1 ring-border/60 ring-inset">
@@ -177,6 +194,7 @@ function DashboardHeader() {
         <Button variant="ghost" size="icon-sm" className="sm:hidden" aria-label="Search">
           <SearchIcon className="size-4" />
         </Button>
+        <ColorModeToggle />
         <Button variant="ghost" size="icon-sm" aria-label="Notifications">
           <BellIcon className="size-4" />
         </Button>

--- a/apps/dashboard/src/app/(dashboard)/settings/theme-customizer.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/theme-customizer.tsx
@@ -14,12 +14,12 @@ import {
   Separator,
   Slider,
   useTheme,
-  defaultLightTheme,
+  defaultTheme,
 } from "@whitelabel/ui";
-import type { ThemeConfig } from "@whitelabel/ui";
+import type { ThemeConfig, ColorTokens } from "@whitelabel/ui";
 import { CheckIcon, RotateCcwIcon } from "lucide-react";
 
-const colorTokenLabels: { key: keyof ThemeConfig["colors"]; label: string }[] = [
+const colorTokenLabels: { key: keyof ColorTokens; label: string }[] = [
   { key: "background", label: "Background" },
   { key: "foreground", label: "Foreground" },
   { key: "primary", label: "Primary" },
@@ -61,22 +61,22 @@ function PresetCard({
       <div className="flex gap-1">
         <div
           className="size-5 rounded-sm ring-1 ring-foreground/10"
-          style={{ backgroundColor: preset.colors.primary }}
+          style={{ backgroundColor: preset.light.primary }}
           title="Primary"
         />
         <div
           className="size-5 rounded-sm ring-1 ring-foreground/10"
-          style={{ backgroundColor: preset.colors.secondary }}
+          style={{ backgroundColor: preset.light.secondary }}
           title="Secondary"
         />
         <div
           className="size-5 rounded-sm ring-1 ring-foreground/10"
-          style={{ backgroundColor: preset.colors.accent }}
+          style={{ backgroundColor: preset.light.accent }}
           title="Accent"
         />
         <div
           className="size-5 rounded-sm ring-1 ring-foreground/10"
-          style={{ backgroundColor: preset.colors.background }}
+          style={{ backgroundColor: preset.light.background }}
           title="Background"
         />
       </div>
@@ -115,20 +115,23 @@ function ColorTokenInput({
 }
 
 export function ThemeCustomizer() {
-  const { theme, setTheme, presets } = useTheme();
+  const { theme, setTheme, presets, colorMode } = useTheme();
   const [draft, setDraft] = useState<ThemeConfig>(theme);
 
+  const activeColors = colorMode === "dark" ? draft.dark : draft.light;
+
   const updateColor = useCallback(
-    (key: keyof ThemeConfig["colors"], value: string) => {
-      const next = {
+    (key: keyof ColorTokens, value: string) => {
+      const modeKey = colorMode === "dark" ? "dark" : "light";
+      const next: ThemeConfig = {
         ...draft,
         name: "custom",
-        colors: { ...draft.colors, [key]: value },
+        [modeKey]: { ...draft[modeKey], [key]: value },
       };
       setDraft(next);
-      setTheme(next); // live preview
+      setTheme(next);
     },
-    [draft, setTheme],
+    [draft, setTheme, colorMode],
   );
 
   const updateRadius = useCallback(
@@ -149,8 +152,8 @@ export function ThemeCustomizer() {
   );
 
   const resetToDefault = useCallback(() => {
-    setDraft(defaultLightTheme);
-    setTheme(defaultLightTheme);
+    setDraft(defaultTheme);
+    setTheme(defaultTheme);
   }, [setTheme]);
 
   const radiusValue = parseFloat(draft.radius) || 0.625;
@@ -182,9 +185,9 @@ export function ThemeCustomizer() {
       {/* Color Tokens */}
       <Card>
         <CardHeader>
-          <CardTitle>Color Tokens</CardTitle>
+          <CardTitle>Color Tokens ({colorMode === "dark" ? "Dark" : "Light"})</CardTitle>
           <CardDescription>
-            Fine-tune individual color values. Changes apply in real-time.
+            Fine-tune individual color values for the current mode. Use the header toggle to switch modes.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -193,7 +196,7 @@ export function ThemeCustomizer() {
               <ColorTokenInput
                 key={key}
                 label={label}
-                value={draft.colors[key]}
+                value={activeColors[key]}
                 onChange={(v) => updateColor(key, v)}
               />
             ))}

--- a/apps/dashboard/src/app/(dashboard)/theme-editor/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/theme-editor/page.tsx
@@ -72,8 +72,9 @@ import {
   TooltipTrigger,
   useTheme,
 } from "@whitelabel/ui";
-import type { ThemeConfig } from "@whitelabel/ui";
+import type { ThemeConfig, ColorTokens } from "@whitelabel/ui";
 import {
+  defaultTheme,
   defaultLightTheme,
   defaultDarkTheme,
   brandBlueTheme,
@@ -100,7 +101,7 @@ import { DashboardScene } from "./dashboard-scene";
 // ---------------------------------------------------------------------------
 const TOKEN_GROUPS: {
   label: string;
-  tokens: { key: keyof ThemeConfig["colors"]; label: string }[];
+  tokens: { key: keyof ColorTokens; label: string }[];
 }[] = [
   {
     label: "Primary",
@@ -188,7 +189,21 @@ function loadCustomThemes(): ThemeConfig[] {
   try {
     const raw = localStorage.getItem(CUSTOM_THEMES_KEY);
     if (!raw) return [];
-    return JSON.parse(raw) as ThemeConfig[];
+    const parsed = JSON.parse(raw) as Array<Record<string, unknown>>;
+    // Migrate legacy themes that have `colors` instead of `light`/`dark`
+    return parsed.map((t) => {
+      if ("light" in t && "dark" in t) return t as unknown as ThemeConfig;
+      const legacy = t as unknown as { name: string; colors: ColorTokens; radius: string; fontFamily?: string; typography?: ThemeConfig["typography"]; adjustments?: ThemeConfig["adjustments"] };
+      return {
+        name: legacy.name,
+        light: legacy.colors,
+        dark: defaultTheme.dark,
+        radius: legacy.radius,
+        fontFamily: legacy.fontFamily,
+        typography: legacy.typography,
+        adjustments: legacy.adjustments,
+      } as ThemeConfig;
+    });
   } catch {
     return [];
   }
@@ -238,7 +253,7 @@ function generateRandomTheme(): ThemeConfig {
   const hue = Math.round(Math.random() * 360);
   const destructiveColor = "oklch(0.577 0.245 27.325)";
 
-  const colors: ThemeConfig["colors"] = {
+  const colors: ColorTokens = {
     background: `oklch(0.985 0.005 ${hue})`,
     foreground: `oklch(0.145 0.02 ${hue})`,
     card: `oklch(0.985 0.005 ${hue})`,
@@ -294,9 +309,49 @@ function generateRandomTheme(): ThemeConfig {
     avatarOverlayBlend: "darken",
   };
 
+  // Generate dark variant by shifting lightness
+  const darkColors: ColorTokens = {
+    ...defaultTheme.dark, // base dark
+    ...Object.fromEntries(
+      Object.entries(colors)
+        .filter(([, v]) => v.includes("oklch"))
+        .map(([k, v]) => [k, v])
+    ),
+  } as ColorTokens;
+  // Darken the dark variant backgrounds
+  darkColors.background = `oklch(0.145 0.01 ${hue})`;
+  darkColors.foreground = `oklch(0.985 0.005 ${hue})`;
+  darkColors.card = `oklch(0.205 0.015 ${hue})`;
+  darkColors.cardForeground = `oklch(0.985 0.005 ${hue})`;
+  darkColors.popover = `oklch(0.205 0.015 ${hue})`;
+  darkColors.popoverForeground = `oklch(0.985 0.005 ${hue})`;
+  darkColors.primary = `oklch(0.6 0.18 ${hue})`;
+  darkColors.secondary = `oklch(0.269 0.02 ${hue})`;
+  darkColors.secondaryForeground = `oklch(0.985 0.005 ${hue})`;
+  darkColors.muted = `oklch(0.269 0.015 ${hue})`;
+  darkColors.mutedForeground = `oklch(0.708 0.02 ${hue})`;
+  darkColors.accent = `oklch(0.269 0.02 ${hue})`;
+  darkColors.accentForeground = `oklch(0.985 0.005 ${hue})`;
+  darkColors.sidebar = `oklch(0.205 0.015 ${hue})`;
+  darkColors.sidebarForeground = `oklch(0.985 0.005 ${hue})`;
+  darkColors.sidebarPrimary = `oklch(0.6 0.18 ${hue})`;
+  darkColors.sidebarAccent = `oklch(0.269 0.02 ${hue})`;
+  darkColors.sidebarAccentForeground = `oklch(0.985 0.005 ${hue})`;
+  darkColors.ring = `oklch(0.6 0.18 ${hue})`;
+  darkColors.sidebarRing = `oklch(0.6 0.18 ${hue})`;
+  darkColors.avatarOverlayBlend = "lighten";
+  darkColors.inputSheer = "oklch(1 0 0 / 30%)";
+  darkColors.inputSheerHover = "oklch(1 0 0 / 50%)";
+  darkColors.border = "oklch(1 0 0 / 10%)";
+  darkColors.input = "oklch(1 0 0 / 15%)";
+  darkColors.borderInput = "oklch(1 0 0 / 15%)";
+  darkColors.sidebarBorder = "oklch(1 0 0 / 10%)";
+  darkColors.activeTabBorder = "oklch(1 0 0 / 15%)";
+
   return {
     name: `random-${hue}`,
-    colors,
+    light: colors,
+    dark: darkColors,
     radius: "0.625rem",
   };
 }
@@ -304,11 +359,11 @@ function generateRandomTheme(): ThemeConfig {
 // ---------------------------------------------------------------------------
 // Derive non-primary tokens from updated primary ones
 // ---------------------------------------------------------------------------
-function deriveFullTheme(
-  base: ThemeConfig,
-  overrides: Partial<ThemeConfig["colors"]>
-): ThemeConfig {
-  const colors = { ...base.colors, ...overrides };
+function deriveColorTokens(
+  base: ColorTokens,
+  overrides: Partial<ColorTokens>
+): ColorTokens {
+  const colors = { ...base, ...overrides };
 
   // Keep derived tokens in sync with primary ones
   colors.popover = colors.background;
@@ -330,14 +385,23 @@ function deriveFullTheme(
   colors.checkedBorder = `${prim.replace(/\)$/, " / 30%)")}`;
   colors.checkedBg = `${prim.replace(/\)$/, " / 5%)")}`;
 
-  return { ...base, colors };
+  return colors;
+}
+
+function deriveFullTheme(
+  base: ThemeConfig,
+  overrides: Partial<ColorTokens>,
+  mode: "light" | "dark"
+): ThemeConfig {
+  const derived = deriveColorTokens(base[mode], overrides);
+  return { ...base, [mode]: derived };
 }
 
 // ---------------------------------------------------------------------------
 // Apply hue shift to all oklch color tokens
 // ---------------------------------------------------------------------------
-function applyHueShift(theme: ThemeConfig, hueOffset: number): ThemeConfig {
-  const colors = { ...theme.colors };
+function shiftColorsHue(tokens: ColorTokens, hueOffset: number): ColorTokens {
+  const colors = { ...tokens };
   const oklchRe = /oklch\(([^)]+)\)/;
 
   for (const key of Object.keys(colors) as (keyof typeof colors)[]) {
@@ -358,9 +422,14 @@ function applyHueShift(theme: ThemeConfig, hueOffset: number): ThemeConfig {
     }
   }
 
+  return colors;
+}
+
+function applyHueShift(theme: ThemeConfig, hueOffset: number): ThemeConfig {
   return {
     ...theme,
-    colors,
+    light: shiftColorsHue(theme.light, hueOffset),
+    dark: shiftColorsHue(theme.dark, hueOffset),
     adjustments: { ...theme.adjustments, hueShift: hueOffset },
   };
 }
@@ -737,7 +806,7 @@ function LivePreview() {
 // Main page
 // ---------------------------------------------------------------------------
 export default function ThemeEditorPage() {
-  const { theme, setTheme, presets } = useTheme();
+  const { theme, setTheme, presets, colorMode } = useTheme();
   // Local draft state so we can batch edits before auto-saving
   const [draft, setDraft] = useState<ThemeConfig>(theme);
 
@@ -789,11 +858,11 @@ export default function ThemeEditorPage() {
   );
 
   const updateColor = useCallback(
-    (key: keyof ThemeConfig["colors"], value: string) => {
-      const derived = deriveFullTheme(draft, { [key]: value });
+    (key: keyof ColorTokens, value: string) => {
+      const derived = deriveFullTheme(draft, { [key]: value }, colorMode);
       applyDraft(derived);
     },
-    [draft, applyDraft]
+    [draft, applyDraft, colorMode]
   );
 
   const handlePreset = useCallback(
@@ -808,7 +877,7 @@ export default function ThemeEditorPage() {
   }, [applyDraft]);
 
   const handleReset = useCallback(() => {
-    applyDraft(defaultLightTheme);
+    applyDraft(defaultTheme);
   }, [applyDraft]);
 
   const handleRadiusChange = useCallback(
@@ -975,10 +1044,10 @@ export default function ThemeEditorPage() {
             >
               <div className="flex gap-1 mb-1.5">
                 {[
-                  preset.colors.primary,
-                  preset.colors.secondary,
-                  preset.colors.accent,
-                  preset.colors.background,
+                  preset.light.primary,
+                  preset.light.secondary,
+                  preset.light.accent,
+                  preset.light.background,
                 ].map((c, i) => (
                   <div
                     key={i}
@@ -1016,10 +1085,10 @@ export default function ThemeEditorPage() {
               >
                 <div className="flex gap-1 mb-1.5">
                   {[
-                    ct.colors.primary,
-                    ct.colors.secondary,
-                    ct.colors.accent,
-                    ct.colors.background,
+                    ct.light.primary,
+                    ct.light.secondary,
+                    ct.light.accent,
+                    ct.light.background,
                   ].map((c, i) => (
                     <div
                       key={i}
@@ -1130,7 +1199,7 @@ export default function ThemeEditorPage() {
                   <TokenEditor
                     key={t.key}
                     label={t.label}
-                    value={draft.colors[t.key]}
+                    value={draft[colorMode][t.key]}
                     onChange={(v) => updateColor(t.key, v)}
                   />
                 ))}

--- a/packages/ui/src/components/theme-provider.tsx
+++ b/packages/ui/src/components/theme-provider.tsx
@@ -7,11 +7,14 @@ import {
   useMemo,
   useState,
 } from "react";
-import type { ThemeConfig } from "../lib/theme-config";
+import type { ColorMode, ThemeConfig } from "../lib/theme-config";
 import {
+  applyColorModeToDOM,
   applyThemeToDOM,
-  defaultLightTheme,
+  defaultTheme,
+  loadColorMode,
   loadThemeFromStorage,
+  saveColorMode,
   saveThemeToStorage,
   themePresets,
 } from "../lib/theme-config";
@@ -23,6 +26,12 @@ export interface ThemeContextValue {
   setTheme: (theme: ThemeConfig) => void;
   /** All available theme presets */
   presets: ThemeConfig[];
+  /** Current color mode (light or dark) */
+  colorMode: ColorMode;
+  /** Toggle between light and dark mode */
+  toggleColorMode: () => void;
+  /** Set a specific color mode */
+  setColorMode: (mode: ColorMode) => void;
 }
 
 export const ThemeContext = createContext<ThemeContextValue | null>(null);
@@ -37,28 +46,45 @@ interface ThemeProviderProps {
 
 export function ThemeProvider({
   children,
-  defaultTheme = defaultLightTheme,
+  defaultTheme: defaultThemeProp = defaultTheme,
   extraPresets = [],
 }: ThemeProviderProps) {
-  const [theme, setThemeState] = useState<ThemeConfig>(defaultTheme);
-  const [mounted, setMounted] = useState(false);
+  const [theme, setThemeState] = useState<ThemeConfig>(defaultThemeProp);
+  const [colorMode, setColorModeState] = useState<ColorMode>("light");
 
-  // Load persisted theme on mount
+  // Load persisted theme and color mode on mount
   useEffect(() => {
     const stored = loadThemeFromStorage();
+    const mode = loadColorMode();
+    const activeTheme = stored || defaultThemeProp;
+
     if (stored) {
       setThemeState(stored);
-      applyThemeToDOM(stored);
-    } else {
-      applyThemeToDOM(defaultTheme);
     }
-    setMounted(true);
-  }, [defaultTheme]);
+    setColorModeState(mode);
+    applyThemeToDOM(activeTheme);
+    applyColorModeToDOM(mode);
+  }, [defaultThemeProp]);
 
   const setTheme = useCallback((newTheme: ThemeConfig) => {
     setThemeState(newTheme);
     applyThemeToDOM(newTheme);
     saveThemeToStorage(newTheme);
+  }, []);
+
+  const setColorMode = useCallback((mode: ColorMode) => {
+    setColorModeState(mode);
+    applyColorModeToDOM(mode);
+    saveColorMode(mode);
+  }, []);
+
+  const toggleColorMode = useCallback(() => {
+    setColorModeState((prev) => {
+      const next = prev === "light" ? "dark" : "light";
+      applyColorModeToDOM(next);
+      saveColorMode(next);
+      return next;
+    });
   }, []);
 
   const presets = useMemo(
@@ -67,16 +93,12 @@ export function ThemeProvider({
   );
 
   const value = useMemo<ThemeContextValue>(
-    () => ({ theme, setTheme, presets }),
-    [theme, setTheme, presets],
+    () => ({ theme, setTheme, presets, colorMode, toggleColorMode, setColorMode }),
+    [theme, setTheme, presets, colorMode, toggleColorMode, setColorMode],
   );
 
-  // Prevent flash of unstyled content — render children only after mount
-  // so the correct CSS vars are in place. We still render the tree in SSR
-  // (via suppressHydrationWarning on <html>) but skip applying vars there.
   return (
     <ThemeContext.Provider value={value}>
-      {/* Always render children for SSR; CSS vars are applied in useEffect */}
       {children}
     </ThemeContext.Provider>
   );

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,13 +5,14 @@ export { cn } from "./lib/utils";
 export { ThemeProvider, ThemeContext } from "./components/theme-provider";
 export type { ThemeContextValue } from "./components/theme-provider";
 export {
+  defaultTheme,
   defaultLightTheme,
   defaultDarkTheme,
   brandBlueTheme,
   brandGreenTheme,
   themePresets,
 } from "./lib/theme-config";
-export type { ThemeConfig } from "./lib/theme-config";
+export type { ThemeConfig, ColorTokens, ColorMode } from "./lib/theme-config";
 
 // Hooks
 export { useIsMobile } from "./hooks/use-mobile";

--- a/packages/ui/src/lib/theme-config.ts
+++ b/packages/ui/src/lib/theme-config.ts
@@ -1,60 +1,62 @@
+export interface ColorTokens {
+  background: string;
+  foreground: string;
+  card: string;
+  cardForeground: string;
+  popover: string;
+  popoverForeground: string;
+  primary: string;
+  primaryForeground: string;
+  secondary: string;
+  secondaryForeground: string;
+  muted: string;
+  mutedForeground: string;
+  accent: string;
+  accentForeground: string;
+  destructive: string;
+  border: string;
+  input: string;
+  ring: string;
+  chart1: string;
+  chart2: string;
+  chart3: string;
+  chart4: string;
+  chart5: string;
+  sidebar: string;
+  sidebarForeground: string;
+  sidebarPrimary: string;
+  sidebarPrimaryForeground: string;
+  sidebarAccent: string;
+  sidebarAccentForeground: string;
+  sidebarBorder: string;
+  sidebarRing: string;
+  inputSheer: string;
+  inputSheerHover: string;
+  inputDisabledBg: string;
+  mutedHover: string;
+  destructiveBg: string;
+  destructiveBgHover: string;
+  destructiveRing: string;
+  destructiveBorder: string;
+  destructiveFocusBg: string;
+  borderInput: string;
+  checkedBorder: string;
+  checkedBg: string;
+  kbdTooltipBg: string;
+  switchUnchecked: string;
+  switchThumbChecked: string;
+  switchThumbUnchecked: string;
+  tabsTriggerText: string;
+  outlineBg: string;
+  outlineBgHover: string;
+  activeTabBorder: string;
+  avatarOverlayBlend: string;
+}
+
 export interface ThemeConfig {
   name: string;
-  colors: {
-    background: string;
-    foreground: string;
-    card: string;
-    cardForeground: string;
-    popover: string;
-    popoverForeground: string;
-    primary: string;
-    primaryForeground: string;
-    secondary: string;
-    secondaryForeground: string;
-    muted: string;
-    mutedForeground: string;
-    accent: string;
-    accentForeground: string;
-    destructive: string;
-
-    border: string;
-    input: string;
-    ring: string;
-    chart1: string;
-    chart2: string;
-    chart3: string;
-    chart4: string;
-    chart5: string;
-    sidebar: string;
-    sidebarForeground: string;
-    sidebarPrimary: string;
-    sidebarPrimaryForeground: string;
-    sidebarAccent: string;
-    sidebarAccentForeground: string;
-    sidebarBorder: string;
-    sidebarRing: string;
-    inputSheer: string;
-    inputSheerHover: string;
-    inputDisabledBg: string;
-    mutedHover: string;
-    destructiveBg: string;
-    destructiveBgHover: string;
-    destructiveRing: string;
-    destructiveBorder: string;
-    destructiveFocusBg: string;
-    borderInput: string;
-    checkedBorder: string;
-    checkedBg: string;
-    kbdTooltipBg: string;
-    switchUnchecked: string;
-    switchThumbChecked: string;
-    switchThumbUnchecked: string;
-    tabsTriggerText: string;
-    outlineBg: string;
-    outlineBgHover: string;
-    activeTabBorder: string;
-    avatarOverlayBlend: string;
-  };
+  light: ColorTokens;
+  dark: ColorTokens;
   radius: string;
   fontFamily?: string;
   typography?: {
@@ -72,127 +74,141 @@ export interface ThemeConfig {
   };
 }
 
-export const defaultLightTheme: ThemeConfig = {
-  name: "default-light",
-  colors: {
-    background: "oklch(1 0 0)",
-    foreground: "oklch(0.145 0 0)",
-    card: "oklch(1 0 0)",
-    cardForeground: "oklch(0.145 0 0)",
-    popover: "oklch(1 0 0)",
-    popoverForeground: "oklch(0.145 0 0)",
-    primary: "oklch(0.205 0 0)",
-    primaryForeground: "oklch(0.985 0 0)",
-    secondary: "oklch(0.97 0 0)",
-    secondaryForeground: "oklch(0.205 0 0)",
-    muted: "oklch(0.97 0 0)",
-    mutedForeground: "oklch(0.556 0 0)",
-    accent: "oklch(0.97 0 0)",
-    accentForeground: "oklch(0.205 0 0)",
-    destructive: "oklch(0.577 0.245 27.325)",
-    border: "oklch(0.922 0 0)",
-    input: "oklch(0.922 0 0)",
-    ring: "oklch(0.708 0 0)",
-    chart1: "oklch(0.87 0 0)",
-    chart2: "oklch(0.556 0 0)",
-    chart3: "oklch(0.439 0 0)",
-    chart4: "oklch(0.371 0 0)",
-    chart5: "oklch(0.269 0 0)",
-    sidebar: "oklch(0.985 0 0)",
-    sidebarForeground: "oklch(0.145 0 0)",
-    sidebarPrimary: "oklch(0.205 0 0)",
-    sidebarPrimaryForeground: "oklch(0.985 0 0)",
-    sidebarAccent: "oklch(0.97 0 0)",
-    sidebarAccentForeground: "oklch(0.205 0 0)",
-    sidebarBorder: "oklch(0.922 0 0)",
-    sidebarRing: "oklch(0.708 0 0)",
-    inputSheer: "transparent",
-    inputSheerHover: "transparent",
-    inputDisabledBg: "oklch(0.922 0 0 / 50%)",
-    mutedHover: "oklch(0.97 0 0)",
-    destructiveBg: "oklch(0.577 0.245 27.325 / 10%)",
-    destructiveBgHover: "oklch(0.577 0.245 27.325 / 20%)",
-    destructiveRing: "oklch(0.577 0.245 27.325 / 20%)",
-    destructiveBorder: "oklch(0.577 0.245 27.325)",
-    destructiveFocusBg: "oklch(0.577 0.245 27.325 / 10%)",
-    borderInput: "oklch(0.922 0 0)",
-    checkedBorder: "oklch(0.205 0 0 / 30%)",
-    checkedBg: "oklch(0.205 0 0 / 5%)",
-    kbdTooltipBg: "oklch(1 0 0 / 20%)",
-    switchUnchecked: "oklch(0.922 0 0)",
-    switchThumbChecked: "oklch(1 0 0)",
-    switchThumbUnchecked: "oklch(1 0 0)",
-    tabsTriggerText: "oklch(0.145 0 0 / 60%)",
-    outlineBg: "oklch(1 0 0)",
-    outlineBgHover: "oklch(0.97 0 0)",
-    activeTabBorder: "transparent",
-    avatarOverlayBlend: "darken",
-  },
+/** @deprecated Use ThemeConfig with light/dark instead */
+export interface LegacyThemeConfig {
+  name: string;
+  colors: ColorTokens;
+  radius: string;
+  fontFamily?: string;
+  typography?: ThemeConfig["typography"];
+  adjustments?: ThemeConfig["adjustments"];
+}
+
+const defaultLightColors: ColorTokens = {
+  background: "oklch(1 0 0)",
+  foreground: "oklch(0.145 0 0)",
+  card: "oklch(1 0 0)",
+  cardForeground: "oklch(0.145 0 0)",
+  popover: "oklch(1 0 0)",
+  popoverForeground: "oklch(0.145 0 0)",
+  primary: "oklch(0.205 0 0)",
+  primaryForeground: "oklch(0.985 0 0)",
+  secondary: "oklch(0.97 0 0)",
+  secondaryForeground: "oklch(0.205 0 0)",
+  muted: "oklch(0.97 0 0)",
+  mutedForeground: "oklch(0.556 0 0)",
+  accent: "oklch(0.97 0 0)",
+  accentForeground: "oklch(0.205 0 0)",
+  destructive: "oklch(0.577 0.245 27.325)",
+  border: "oklch(0.922 0 0)",
+  input: "oklch(0.922 0 0)",
+  ring: "oklch(0.708 0 0)",
+  chart1: "oklch(0.87 0 0)",
+  chart2: "oklch(0.556 0 0)",
+  chart3: "oklch(0.439 0 0)",
+  chart4: "oklch(0.371 0 0)",
+  chart5: "oklch(0.269 0 0)",
+  sidebar: "oklch(0.985 0 0)",
+  sidebarForeground: "oklch(0.145 0 0)",
+  sidebarPrimary: "oklch(0.205 0 0)",
+  sidebarPrimaryForeground: "oklch(0.985 0 0)",
+  sidebarAccent: "oklch(0.97 0 0)",
+  sidebarAccentForeground: "oklch(0.205 0 0)",
+  sidebarBorder: "oklch(0.922 0 0)",
+  sidebarRing: "oklch(0.708 0 0)",
+  inputSheer: "transparent",
+  inputSheerHover: "transparent",
+  inputDisabledBg: "oklch(0.922 0 0 / 50%)",
+  mutedHover: "oklch(0.97 0 0)",
+  destructiveBg: "oklch(0.577 0.245 27.325 / 10%)",
+  destructiveBgHover: "oklch(0.577 0.245 27.325 / 20%)",
+  destructiveRing: "oklch(0.577 0.245 27.325 / 20%)",
+  destructiveBorder: "oklch(0.577 0.245 27.325)",
+  destructiveFocusBg: "oklch(0.577 0.245 27.325 / 10%)",
+  borderInput: "oklch(0.922 0 0)",
+  checkedBorder: "oklch(0.205 0 0 / 30%)",
+  checkedBg: "oklch(0.205 0 0 / 5%)",
+  kbdTooltipBg: "oklch(1 0 0 / 20%)",
+  switchUnchecked: "oklch(0.922 0 0)",
+  switchThumbChecked: "oklch(1 0 0)",
+  switchThumbUnchecked: "oklch(1 0 0)",
+  tabsTriggerText: "oklch(0.145 0 0 / 60%)",
+  outlineBg: "oklch(1 0 0)",
+  outlineBgHover: "oklch(0.97 0 0)",
+  activeTabBorder: "transparent",
+  avatarOverlayBlend: "darken",
+};
+
+const defaultDarkColors: ColorTokens = {
+  background: "oklch(0.145 0 0)",
+  foreground: "oklch(0.985 0 0)",
+  card: "oklch(0.205 0 0)",
+  cardForeground: "oklch(0.985 0 0)",
+  popover: "oklch(0.205 0 0)",
+  popoverForeground: "oklch(0.985 0 0)",
+  primary: "oklch(0.922 0 0)",
+  primaryForeground: "oklch(0.205 0 0)",
+  secondary: "oklch(0.269 0 0)",
+  secondaryForeground: "oklch(0.985 0 0)",
+  muted: "oklch(0.269 0 0)",
+  mutedForeground: "oklch(0.708 0 0)",
+  accent: "oklch(0.269 0 0)",
+  accentForeground: "oklch(0.985 0 0)",
+  destructive: "oklch(0.704 0.191 22.216)",
+  border: "oklch(1 0 0 / 10%)",
+  input: "oklch(1 0 0 / 15%)",
+  ring: "oklch(0.556 0 0)",
+  chart1: "oklch(0.87 0 0)",
+  chart2: "oklch(0.556 0 0)",
+  chart3: "oklch(0.439 0 0)",
+  chart4: "oklch(0.371 0 0)",
+  chart5: "oklch(0.269 0 0)",
+  sidebar: "oklch(0.205 0 0)",
+  sidebarForeground: "oklch(0.985 0 0)",
+  sidebarPrimary: "oklch(0.488 0.243 264.376)",
+  sidebarPrimaryForeground: "oklch(0.985 0 0)",
+  sidebarAccent: "oklch(0.269 0 0)",
+  sidebarAccentForeground: "oklch(0.985 0 0)",
+  sidebarBorder: "oklch(1 0 0 / 10%)",
+  sidebarRing: "oklch(0.556 0 0)",
+  inputSheer: "oklch(1 0 0 / 30%)",
+  inputSheerHover: "oklch(1 0 0 / 50%)",
+  inputDisabledBg: "oklch(1 0 0 / 80%)",
+  mutedHover: "oklch(0.269 0 0 / 50%)",
+  destructiveBg: "oklch(0.704 0.191 22.216 / 20%)",
+  destructiveBgHover: "oklch(0.704 0.191 22.216 / 30%)",
+  destructiveRing: "oklch(0.704 0.191 22.216 / 40%)",
+  destructiveBorder: "oklch(0.704 0.191 22.216 / 50%)",
+  destructiveFocusBg: "oklch(0.704 0.191 22.216 / 20%)",
+  borderInput: "oklch(1 0 0 / 15%)",
+  checkedBorder: "oklch(0.922 0 0 / 20%)",
+  checkedBg: "oklch(0.922 0 0 / 10%)",
+  kbdTooltipBg: "oklch(0.145 0 0 / 10%)",
+  switchUnchecked: "oklch(1 0 0 / 80%)",
+  switchThumbChecked: "oklch(0.205 0 0)",
+  switchThumbUnchecked: "oklch(0.985 0 0)",
+  tabsTriggerText: "oklch(0.708 0 0)",
+  outlineBg: "oklch(1 0 0 / 30%)",
+  outlineBgHover: "oklch(1 0 0 / 50%)",
+  activeTabBorder: "oklch(1 0 0 / 15%)",
+  avatarOverlayBlend: "lighten",
+};
+
+export const defaultTheme: ThemeConfig = {
+  name: "default",
+  light: defaultLightColors,
+  dark: defaultDarkColors,
   radius: "0.625rem",
 };
 
-export const defaultDarkTheme: ThemeConfig = {
-  name: "default-dark",
-  colors: {
-    background: "oklch(0.145 0 0)",
-    foreground: "oklch(0.985 0 0)",
-    card: "oklch(0.205 0 0)",
-    cardForeground: "oklch(0.985 0 0)",
-    popover: "oklch(0.205 0 0)",
-    popoverForeground: "oklch(0.985 0 0)",
-    primary: "oklch(0.922 0 0)",
-    primaryForeground: "oklch(0.205 0 0)",
-    secondary: "oklch(0.269 0 0)",
-    secondaryForeground: "oklch(0.985 0 0)",
-    muted: "oklch(0.269 0 0)",
-    mutedForeground: "oklch(0.708 0 0)",
-    accent: "oklch(0.269 0 0)",
-    accentForeground: "oklch(0.985 0 0)",
-    destructive: "oklch(0.704 0.191 22.216)",
-    border: "oklch(1 0 0 / 10%)",
-    input: "oklch(1 0 0 / 15%)",
-    ring: "oklch(0.556 0 0)",
-    chart1: "oklch(0.87 0 0)",
-    chart2: "oklch(0.556 0 0)",
-    chart3: "oklch(0.439 0 0)",
-    chart4: "oklch(0.371 0 0)",
-    chart5: "oklch(0.269 0 0)",
-    sidebar: "oklch(0.205 0 0)",
-    sidebarForeground: "oklch(0.985 0 0)",
-    sidebarPrimary: "oklch(0.488 0.243 264.376)",
-    sidebarPrimaryForeground: "oklch(0.985 0 0)",
-    sidebarAccent: "oklch(0.269 0 0)",
-    sidebarAccentForeground: "oklch(0.985 0 0)",
-    sidebarBorder: "oklch(1 0 0 / 10%)",
-    sidebarRing: "oklch(0.556 0 0)",
-    inputSheer: "oklch(1 0 0 / 30%)",
-    inputSheerHover: "oklch(1 0 0 / 50%)",
-    inputDisabledBg: "oklch(1 0 0 / 80%)",
-    mutedHover: "oklch(0.269 0 0 / 50%)",
-    destructiveBg: "oklch(0.704 0.191 22.216 / 20%)",
-    destructiveBgHover: "oklch(0.704 0.191 22.216 / 30%)",
-    destructiveRing: "oklch(0.704 0.191 22.216 / 40%)",
-    destructiveBorder: "oklch(0.704 0.191 22.216 / 50%)",
-    destructiveFocusBg: "oklch(0.704 0.191 22.216 / 20%)",
-    borderInput: "oklch(1 0 0 / 15%)",
-    checkedBorder: "oklch(0.922 0 0 / 20%)",
-    checkedBg: "oklch(0.922 0 0 / 10%)",
-    kbdTooltipBg: "oklch(0.145 0 0 / 10%)",
-    switchUnchecked: "oklch(1 0 0 / 80%)",
-    switchThumbChecked: "oklch(0.205 0 0)",
-    switchThumbUnchecked: "oklch(0.985 0 0)",
-    tabsTriggerText: "oklch(0.708 0 0)",
-    outlineBg: "oklch(1 0 0 / 30%)",
-    outlineBgHover: "oklch(1 0 0 / 50%)",
-    activeTabBorder: "oklch(1 0 0 / 15%)",
-    avatarOverlayBlend: "lighten",
-  },
-  radius: "0.625rem",
-};
+/** @deprecated Use defaultTheme instead */
+export const defaultLightTheme = defaultTheme;
+/** @deprecated Use defaultTheme instead */
+export const defaultDarkTheme = defaultTheme;
 
 export const brandBlueTheme: ThemeConfig = {
   name: "brand-blue",
-  colors: {
+  light: {
     background: "oklch(0.985 0.002 250)",
     foreground: "oklch(0.145 0.02 250)",
     card: "oklch(0.985 0.002 250)",
@@ -246,12 +262,66 @@ export const brandBlueTheme: ThemeConfig = {
     activeTabBorder: "transparent",
     avatarOverlayBlend: "darken",
   },
+  dark: {
+    background: "oklch(0.145 0.01 250)",
+    foreground: "oklch(0.985 0.005 250)",
+    card: "oklch(0.205 0.015 250)",
+    cardForeground: "oklch(0.985 0.005 250)",
+    popover: "oklch(0.205 0.015 250)",
+    popoverForeground: "oklch(0.985 0.005 250)",
+    primary: "oklch(0.6 0.2 264.376)",
+    primaryForeground: "oklch(0.985 0 0)",
+    secondary: "oklch(0.269 0.02 250)",
+    secondaryForeground: "oklch(0.985 0.005 250)",
+    muted: "oklch(0.269 0.015 250)",
+    mutedForeground: "oklch(0.708 0.02 250)",
+    accent: "oklch(0.269 0.02 250)",
+    accentForeground: "oklch(0.985 0.005 250)",
+    destructive: "oklch(0.704 0.191 22.216)",
+    border: "oklch(1 0 0 / 10%)",
+    input: "oklch(1 0 0 / 15%)",
+    ring: "oklch(0.6 0.2 264.376)",
+    chart1: "oklch(0.87 0.05 250)",
+    chart2: "oklch(0.556 0.05 250)",
+    chart3: "oklch(0.439 0.05 250)",
+    chart4: "oklch(0.371 0.05 250)",
+    chart5: "oklch(0.269 0.05 250)",
+    sidebar: "oklch(0.205 0.015 250)",
+    sidebarForeground: "oklch(0.985 0.005 250)",
+    sidebarPrimary: "oklch(0.6 0.2 264.376)",
+    sidebarPrimaryForeground: "oklch(0.985 0 0)",
+    sidebarAccent: "oklch(0.269 0.02 250)",
+    sidebarAccentForeground: "oklch(0.985 0.005 250)",
+    sidebarBorder: "oklch(1 0 0 / 10%)",
+    sidebarRing: "oklch(0.6 0.2 264.376)",
+    inputSheer: "oklch(1 0 0 / 30%)",
+    inputSheerHover: "oklch(1 0 0 / 50%)",
+    inputDisabledBg: "oklch(1 0 0 / 80%)",
+    mutedHover: "oklch(0.269 0.02 250 / 50%)",
+    destructiveBg: "oklch(0.704 0.191 22.216 / 20%)",
+    destructiveBgHover: "oklch(0.704 0.191 22.216 / 30%)",
+    destructiveRing: "oklch(0.704 0.191 22.216 / 40%)",
+    destructiveBorder: "oklch(0.704 0.191 22.216 / 50%)",
+    destructiveFocusBg: "oklch(0.704 0.191 22.216 / 20%)",
+    borderInput: "oklch(1 0 0 / 15%)",
+    checkedBorder: "oklch(0.6 0.2 264.376 / 20%)",
+    checkedBg: "oklch(0.6 0.2 264.376 / 10%)",
+    kbdTooltipBg: "oklch(0.145 0.01 250 / 10%)",
+    switchUnchecked: "oklch(1 0 0 / 80%)",
+    switchThumbChecked: "oklch(0.205 0.015 250)",
+    switchThumbUnchecked: "oklch(0.985 0.005 250)",
+    tabsTriggerText: "oklch(0.708 0.02 250)",
+    outlineBg: "oklch(1 0 0 / 30%)",
+    outlineBgHover: "oklch(1 0 0 / 50%)",
+    activeTabBorder: "oklch(1 0 0 / 15%)",
+    avatarOverlayBlend: "lighten",
+  },
   radius: "0.75rem",
 };
 
 export const brandGreenTheme: ThemeConfig = {
   name: "brand-green",
-  colors: {
+  light: {
     background: "oklch(0.985 0.005 155)",
     foreground: "oklch(0.145 0.02 155)",
     card: "oklch(0.985 0.005 155)",
@@ -305,24 +375,127 @@ export const brandGreenTheme: ThemeConfig = {
     activeTabBorder: "transparent",
     avatarOverlayBlend: "darken",
   },
+  dark: {
+    background: "oklch(0.145 0.01 155)",
+    foreground: "oklch(0.985 0.005 155)",
+    card: "oklch(0.205 0.015 155)",
+    cardForeground: "oklch(0.985 0.005 155)",
+    popover: "oklch(0.205 0.015 155)",
+    popoverForeground: "oklch(0.985 0.005 155)",
+    primary: "oklch(0.65 0.15 155)",
+    primaryForeground: "oklch(0.985 0 0)",
+    secondary: "oklch(0.269 0.02 155)",
+    secondaryForeground: "oklch(0.985 0.005 155)",
+    muted: "oklch(0.269 0.015 155)",
+    mutedForeground: "oklch(0.708 0.02 155)",
+    accent: "oklch(0.269 0.02 155)",
+    accentForeground: "oklch(0.985 0.005 155)",
+    destructive: "oklch(0.704 0.191 22.216)",
+    border: "oklch(1 0 0 / 10%)",
+    input: "oklch(1 0 0 / 15%)",
+    ring: "oklch(0.65 0.15 155)",
+    chart1: "oklch(0.87 0.05 155)",
+    chart2: "oklch(0.556 0.05 155)",
+    chart3: "oklch(0.439 0.05 155)",
+    chart4: "oklch(0.371 0.05 155)",
+    chart5: "oklch(0.269 0.05 155)",
+    sidebar: "oklch(0.205 0.015 155)",
+    sidebarForeground: "oklch(0.985 0.005 155)",
+    sidebarPrimary: "oklch(0.65 0.15 155)",
+    sidebarPrimaryForeground: "oklch(0.985 0 0)",
+    sidebarAccent: "oklch(0.269 0.02 155)",
+    sidebarAccentForeground: "oklch(0.985 0.005 155)",
+    sidebarBorder: "oklch(1 0 0 / 10%)",
+    sidebarRing: "oklch(0.65 0.15 155)",
+    inputSheer: "oklch(1 0 0 / 30%)",
+    inputSheerHover: "oklch(1 0 0 / 50%)",
+    inputDisabledBg: "oklch(1 0 0 / 80%)",
+    mutedHover: "oklch(0.269 0.02 155 / 50%)",
+    destructiveBg: "oklch(0.704 0.191 22.216 / 20%)",
+    destructiveBgHover: "oklch(0.704 0.191 22.216 / 30%)",
+    destructiveRing: "oklch(0.704 0.191 22.216 / 40%)",
+    destructiveBorder: "oklch(0.704 0.191 22.216 / 50%)",
+    destructiveFocusBg: "oklch(0.704 0.191 22.216 / 20%)",
+    borderInput: "oklch(1 0 0 / 15%)",
+    checkedBorder: "oklch(0.65 0.15 155 / 20%)",
+    checkedBg: "oklch(0.65 0.15 155 / 10%)",
+    kbdTooltipBg: "oklch(0.145 0.01 155 / 10%)",
+    switchUnchecked: "oklch(1 0 0 / 80%)",
+    switchThumbChecked: "oklch(0.205 0.015 155)",
+    switchThumbUnchecked: "oklch(0.985 0.005 155)",
+    tabsTriggerText: "oklch(0.708 0.02 155)",
+    outlineBg: "oklch(1 0 0 / 30%)",
+    outlineBgHover: "oklch(1 0 0 / 50%)",
+    activeTabBorder: "oklch(1 0 0 / 15%)",
+    avatarOverlayBlend: "lighten",
+  },
   radius: "0.5rem",
 };
 
 export const themePresets: ThemeConfig[] = [
-  defaultLightTheme,
-  defaultDarkTheme,
+  defaultTheme,
   brandBlueTheme,
   brandGreenTheme,
 ];
 
 const STORAGE_KEY = "whitelabel-theme";
+const COLOR_MODE_KEY = "whitelabel-color-mode";
+
+export type ColorMode = "light" | "dark";
+
+export function loadColorMode(): ColorMode {
+  if (typeof window === "undefined") return "light";
+  try {
+    const stored = localStorage.getItem(COLOR_MODE_KEY);
+    if (stored === "light" || stored === "dark") return stored;
+  } catch {
+    // ignore
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+export function saveColorMode(mode: ColorMode): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(COLOR_MODE_KEY, mode);
+  } catch {
+    // ignore
+  }
+}
+
+export function applyColorModeToDOM(mode: ColorMode): void {
+  const root = document.documentElement;
+  if (mode === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+}
+
+/** Migrate legacy single-mode ThemeConfig to dual-mode */
+function migrateLegacyTheme(stored: LegacyThemeConfig | ThemeConfig): ThemeConfig {
+  if ("light" in stored && "dark" in stored) {
+    return stored as ThemeConfig;
+  }
+  const legacy = stored as LegacyThemeConfig;
+  return {
+    name: legacy.name,
+    light: legacy.colors,
+    dark: defaultDarkColors,
+    radius: legacy.radius,
+    fontFamily: legacy.fontFamily,
+    typography: legacy.typography,
+    adjustments: legacy.adjustments,
+  };
+}
 
 export function loadThemeFromStorage(): ThemeConfig | null {
   if (typeof window === "undefined") return null;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
-    return JSON.parse(raw) as ThemeConfig;
+    const parsed = JSON.parse(raw);
+    return migrateLegacyTheme(parsed);
   } catch {
     return null;
   }
@@ -337,74 +510,97 @@ export function saveThemeToStorage(theme: ThemeConfig): void {
   }
 }
 
+function colorTokensToCSS(tokens: ColorTokens): string {
+  return [
+    `--background: ${tokens.background}`,
+    `--foreground: ${tokens.foreground}`,
+    `--card: ${tokens.card}`,
+    `--card-foreground: ${tokens.cardForeground}`,
+    `--popover: ${tokens.popover}`,
+    `--popover-foreground: ${tokens.popoverForeground}`,
+    `--primary: ${tokens.primary}`,
+    `--primary-foreground: ${tokens.primaryForeground}`,
+    `--secondary: ${tokens.secondary}`,
+    `--secondary-foreground: ${tokens.secondaryForeground}`,
+    `--muted: ${tokens.muted}`,
+    `--muted-foreground: ${tokens.mutedForeground}`,
+    `--accent: ${tokens.accent}`,
+    `--accent-foreground: ${tokens.accentForeground}`,
+    `--destructive: ${tokens.destructive}`,
+    `--border: ${tokens.border}`,
+    `--input: ${tokens.input}`,
+    `--ring: ${tokens.ring}`,
+    `--chart-1: ${tokens.chart1}`,
+    `--chart-2: ${tokens.chart2}`,
+    `--chart-3: ${tokens.chart3}`,
+    `--chart-4: ${tokens.chart4}`,
+    `--chart-5: ${tokens.chart5}`,
+    `--sidebar: ${tokens.sidebar}`,
+    `--sidebar-foreground: ${tokens.sidebarForeground}`,
+    `--sidebar-primary: ${tokens.sidebarPrimary}`,
+    `--sidebar-primary-foreground: ${tokens.sidebarPrimaryForeground}`,
+    `--sidebar-accent: ${tokens.sidebarAccent}`,
+    `--sidebar-accent-foreground: ${tokens.sidebarAccentForeground}`,
+    `--sidebar-border: ${tokens.sidebarBorder}`,
+    `--sidebar-ring: ${tokens.sidebarRing}`,
+    `--input-sheer: ${tokens.inputSheer}`,
+    `--input-sheer-hover: ${tokens.inputSheerHover}`,
+    `--input-disabled-bg: ${tokens.inputDisabledBg}`,
+    `--muted-hover: ${tokens.mutedHover}`,
+    `--destructive-bg: ${tokens.destructiveBg}`,
+    `--destructive-bg-hover: ${tokens.destructiveBgHover}`,
+    `--destructive-ring: ${tokens.destructiveRing}`,
+    `--destructive-border: ${tokens.destructiveBorder}`,
+    `--destructive-focus-bg: ${tokens.destructiveFocusBg}`,
+    `--border-input: ${tokens.borderInput}`,
+    `--checked-border: ${tokens.checkedBorder}`,
+    `--checked-bg: ${tokens.checkedBg}`,
+    `--kbd-tooltip-bg: ${tokens.kbdTooltipBg}`,
+    `--switch-unchecked: ${tokens.switchUnchecked}`,
+    `--switch-thumb-checked: ${tokens.switchThumbChecked}`,
+    `--switch-thumb-unchecked: ${tokens.switchThumbUnchecked}`,
+    `--tabs-trigger-text: ${tokens.tabsTriggerText}`,
+    `--outline-bg: ${tokens.outlineBg}`,
+    `--outline-bg-hover: ${tokens.outlineBgHover}`,
+    `--active-tab-border: ${tokens.activeTabBorder}`,
+    `--avatar-overlay-blend: ${tokens.avatarOverlayBlend}`,
+  ].join("; ");
+}
+
+const STYLE_ID = "whitelabel-theme-vars";
+
 export function applyThemeToDOM(theme: ThemeConfig): void {
   const root = document.documentElement;
-  root.style.setProperty("--background", theme.colors.background);
-  root.style.setProperty("--foreground", theme.colors.foreground);
-  root.style.setProperty("--card", theme.colors.card);
-  root.style.setProperty("--card-foreground", theme.colors.cardForeground);
-  root.style.setProperty("--popover", theme.colors.popover);
-  root.style.setProperty("--popover-foreground", theme.colors.popoverForeground);
-  root.style.setProperty("--primary", theme.colors.primary);
-  root.style.setProperty("--primary-foreground", theme.colors.primaryForeground);
-  root.style.setProperty("--secondary", theme.colors.secondary);
-  root.style.setProperty("--secondary-foreground", theme.colors.secondaryForeground);
-  root.style.setProperty("--muted", theme.colors.muted);
-  root.style.setProperty("--muted-foreground", theme.colors.mutedForeground);
-  root.style.setProperty("--accent", theme.colors.accent);
-  root.style.setProperty("--accent-foreground", theme.colors.accentForeground);
-  root.style.setProperty("--destructive", theme.colors.destructive);
-  root.style.setProperty("--border", theme.colors.border);
-  root.style.setProperty("--input", theme.colors.input);
-  root.style.setProperty("--ring", theme.colors.ring);
-  root.style.setProperty("--chart-1", theme.colors.chart1);
-  root.style.setProperty("--chart-2", theme.colors.chart2);
-  root.style.setProperty("--chart-3", theme.colors.chart3);
-  root.style.setProperty("--chart-4", theme.colors.chart4);
-  root.style.setProperty("--chart-5", theme.colors.chart5);
-  root.style.setProperty("--sidebar", theme.colors.sidebar);
-  root.style.setProperty("--sidebar-foreground", theme.colors.sidebarForeground);
-  root.style.setProperty("--sidebar-primary", theme.colors.sidebarPrimary);
-  root.style.setProperty("--sidebar-primary-foreground", theme.colors.sidebarPrimaryForeground);
-  root.style.setProperty("--sidebar-accent", theme.colors.sidebarAccent);
-  root.style.setProperty("--sidebar-accent-foreground", theme.colors.sidebarAccentForeground);
-  root.style.setProperty("--sidebar-border", theme.colors.sidebarBorder);
-  root.style.setProperty("--sidebar-ring", theme.colors.sidebarRing);
-  root.style.setProperty("--input-sheer", theme.colors.inputSheer);
-  root.style.setProperty("--input-sheer-hover", theme.colors.inputSheerHover);
-  root.style.setProperty("--input-disabled-bg", theme.colors.inputDisabledBg);
-  root.style.setProperty("--muted-hover", theme.colors.mutedHover);
-  root.style.setProperty("--destructive-bg", theme.colors.destructiveBg);
-  root.style.setProperty("--destructive-bg-hover", theme.colors.destructiveBgHover);
-  root.style.setProperty("--destructive-ring", theme.colors.destructiveRing);
-  root.style.setProperty("--destructive-border", theme.colors.destructiveBorder);
-  root.style.setProperty("--destructive-focus-bg", theme.colors.destructiveFocusBg);
-  root.style.setProperty("--border-input", theme.colors.borderInput);
-  root.style.setProperty("--checked-border", theme.colors.checkedBorder);
-  root.style.setProperty("--checked-bg", theme.colors.checkedBg);
-  root.style.setProperty("--kbd-tooltip-bg", theme.colors.kbdTooltipBg);
-  root.style.setProperty("--switch-unchecked", theme.colors.switchUnchecked);
-  root.style.setProperty("--switch-thumb-checked", theme.colors.switchThumbChecked);
-  root.style.setProperty("--switch-thumb-unchecked", theme.colors.switchThumbUnchecked);
-  root.style.setProperty("--tabs-trigger-text", theme.colors.tabsTriggerText);
-  root.style.setProperty("--outline-bg", theme.colors.outlineBg);
-  root.style.setProperty("--outline-bg-hover", theme.colors.outlineBgHover);
-  root.style.setProperty("--active-tab-border", theme.colors.activeTabBorder);
-  root.style.setProperty("--avatar-overlay-blend", theme.colors.avatarOverlayBlend);
-  root.style.setProperty("--radius", theme.radius);
-  // Font family — always reset to avoid stale values
+
+  // Inject both light and dark vars via a <style> element
+  let styleEl = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
+  if (!styleEl) {
+    styleEl = document.createElement("style");
+    styleEl.id = STYLE_ID;
+    document.head.appendChild(styleEl);
+  }
+
+  const lightCSS = colorTokensToCSS(theme.light);
+  const darkCSS = colorTokensToCSS(theme.dark);
+
+  styleEl.textContent = `
+:root { ${lightCSS}; --radius: ${theme.radius}; }
+.dark { ${darkCSS}; }
+`;
+
+  // Font family
   if (theme.fontFamily || theme.typography?.fontSans) {
     root.style.setProperty("--font-sans", theme.typography?.fontSans || theme.fontFamily || "");
   } else {
     root.style.removeProperty("--font-sans");
   }
 
-  // Typography — always set (reset to defaults when absent)
+  // Typography
   root.style.setProperty("--font-serif", theme.typography?.fontSerif || "");
   root.style.setProperty("--font-mono", theme.typography?.fontMono || "");
   root.style.setProperty("--tracking-body", theme.typography?.letterSpacing || "normal");
 
-  // Adjustments — always set (reset to defaults when absent)
+  // Adjustments
   const spacing = theme.adjustments?.spacingMultiplier ?? 1;
   root.style.setProperty("--spacing-multiplier", String(spacing));
 


### PR DESCRIPTION
Closes #62

Implemented by agent `be-20260325-010103`.

### Changes

**ThemeConfig restructure:**
- Changed `ThemeConfig` to contain `light: ColorTokens` and `dark: ColorTokens` instead of a single `colors` set
- Exported new `ColorTokens` and `ColorMode` types
- Merged `defaultLightTheme`/`defaultDarkTheme` into single `defaultTheme` (kept deprecated aliases for compat)
- Added dark variants for `brandBlueTheme` and `brandGreenTheme`
- `applyThemeToDOM()` now injects both `:root` (light) and `.dark` CSS vars via a `<style>` element

**Header light/dark toggle:**
- Added sun/moon icon button in dashboard header (right side, before notifications)
- Toggles `.dark` class on `<html>` element
- Persists preference in localStorage (`whitelabel-color-mode`)
- On first load: uses `prefers-color-scheme` as default, then localStorage override

**ThemeProvider updates:**
- Added `colorMode`, `toggleColorMode`, `setColorMode` to context
- Loads color mode preference on mount

**Migration:**
- Legacy single-mode themes in localStorage are auto-migrated (treated as light, with default dark)
- Custom themes in theme editor also migrated on load

**Theme Editor + Customizer updates:**
- Color token editing operates on the current color mode's tokens
- Randomize and hue shift apply to both light and dark variants