### PR TITLE
[ops-20260411-0042495] 在 apps/dashboard 新增 instrumentation.ts 接入 OTel

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -7,3 +7,11 @@ NEXT_PUBLIC_SENTRY_DSN=
 SENTRY_AUTH_TOKEN=
 SENTRY_ORG=
 SENTRY_PROJECT=
+
+# OpenTelemetry — server-side traces
+# Leave blank to disable tracing locally; instrumentation.ts logs a warning
+# and the app boots normally. Set OTEL_EXPORTER_OTLP_ENDPOINT to an OTLP/HTTP
+# collector (e.g. Axiom, Grafana Cloud OTLP ingest) to enable.
+# Headers format: "key1=value1,key2=value2" (used for auth tokens).
+OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_EXPORTER_OTLP_HEADERS=

--- a/apps/dashboard/instrumentation.ts
+++ b/apps/dashboard/instrumentation.ts
@@ -1,0 +1,9 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { initTracing } = await import("@whitelabel/otel");
+    initTracing({
+      serviceName: "whitelabel-dashboard",
+      environment: process.env.NODE_ENV,
+    });
+  }
+}

--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@whitelabel/ui"],
+  transpilePackages: ["@whitelabel/ui", "@whitelabel/otel"],
 };
 
 export default withSentryConfig(nextConfig, {


### PR DESCRIPTION
Closes #82

Implemented by agent `ops-20260411-0042495`.

## Summary

Wires the OTel SDK (`@whitelabel/otel`, landed in #94) into the Next.js dashboard via the `instrumentation.ts` `register()` hook.

- **`apps/dashboard/instrumentation.ts`** (new) — `register()` gated on `NEXT_RUNTIME === 'nodejs'`, dynamically imports `@whitelabel/otel` so the SDK never lands in the client bundle or the Edge runtime
- **`apps/dashboard/next.config.ts`** — added `@whitelabel/otel` to `transpilePackages` alongside `@whitelabel/ui`
- **`apps/dashboard/.env.example`** — documented `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` with a note about the graceful-skip behavior

## Spec deviation

Did NOT set `experimental.instrumentationHook: true`. Next 16 canary (`16.2.1-canary.31`) enabled the hook unconditionally and removed the flag from the config schema — adding it would trigger a config warning. Verified by the live dev-server boot.

## Validation

- `pnpm build` → ✅ compiled in 3.4s, all 6 routes prerendered, TypeScript clean
- `pnpm dev` → ✅ `Ready in 260ms`, console showed:
  ```
  [@whitelabel/otel] OTEL_EXPORTER_OTLP_ENDPOINT not set — tracing disabled
  ```
  This single boot confirms all three runtime acceptance criteria: instrumentation loads, graceful-skip fires, dev server still becomes ready.
- Did NOT run a live trace export — needs a real OTLP endpoint (Axiom / Grafana Cloud), out of OPS scope. Task #84 (QA) will verify the happy path once an endpoint is provisioned.

## Out of scope

- Live OTLP backend — #84
- Edge runtime tracing — the `NEXT_RUNTIME === 'nodejs'` guard explicitly excludes it per spec