### PR TITLE
[be-20260414-1014081] Go 後端服務骨架 (apps/server)

### DIFF
--- a/apps/server/.gitignore
+++ b/apps/server/.gitignore
@@ -1,0 +1,2 @@
+# Build binary
+server

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,0 +1,21 @@
+# Stage 1: Build
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /server .
+
+# Stage 2: Run
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /server /server
+
+EXPOSE 8080
+
+ENTRYPOINT ["/server"]

--- a/apps/server/db.go
+++ b/apps/server/db.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// tursoConn wraps *sql.DB and implements the pinger interface.
+type tursoConn struct {
+	db *sql.DB
+}
+
+func openDB(dbURL, authToken string) (*tursoConn, error) {
+	dsn := dbURL
+	if authToken != "" {
+		dsn = fmt.Sprintf("%s?authToken=%s", dbURL, authToken)
+	}
+
+	db, err := sql.Open("libsql", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("sql.Open: %w", err)
+	}
+
+	if err := db.Ping(); err != nil {
+		return nil, fmt.Errorf("db.Ping: %w", err)
+	}
+
+	return &tursoConn{db: db}, nil
+}
+
+func (t *tursoConn) Ping() error {
+	return t.db.Ping()
+}
+
+func (t *tursoConn) Close() error {
+	return t.db.Close()
+}

--- a/apps/server/fly.toml
+++ b/apps/server/fly.toml
@@ -1,0 +1,24 @@
+app = "whitelabel-admin-api"
+primary_region = "nrt"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = "requests"
+    hard_limit = 250
+    soft_limit = 200
+
+[[http_service.checks]]
+  grace_period = "5s"
+  interval = "15s"
+  method = "GET"
+  path = "/api/health"
+  timeout = "2s"

--- a/apps/server/go.mod
+++ b/apps/server/go.mod
@@ -1,0 +1,11 @@
+module github.com/liyoclaw1242/whitelabel-admin/apps/server
+
+go 1.26.2
+
+require github.com/tursodatabase/libsql-client-go v0.0.0-20251219100830-236aa1ff8acc
+
+require (
+	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/coder/websocket v1.8.12 // indirect
+	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 // indirect
+)

--- a/apps/server/go.sum
+++ b/apps/server/go.sum
@@ -1,0 +1,8 @@
+github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
+github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
+github.com/tursodatabase/libsql-client-go v0.0.0-20251219100830-236aa1ff8acc h1:lzi/5fg2EfinRlh3v//YyIhnc4tY7BTqazQGwb1ar+0=
+github.com/tursodatabase/libsql-client-go v0.0.0-20251219100830-236aa1ff8acc/go.mod h1:08inkKyguB6CGGssc/JzhmQWwBgFQBgjlYFjxjRh7nU=
+golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 h1:aAcj0Da7eBAtrTp03QXWvm88pSyOt+UgdZw2BFZ+lEw=
+golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8/go.mod h1:CQ1k9gNrJ50XIzaKCRR2hssIjF07kZFEiieALBM/ARQ=

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	_ "github.com/tursodatabase/libsql-client-go/libsql"
+)
+
+var errDBDown = errors.New("database unreachable")
+
+// pinger abstracts DB connectivity checks.
+type pinger interface {
+	Ping() error
+}
+
+// healthHandler returns an http.HandlerFunc that checks DB connectivity.
+func healthHandler(db pinger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		resp := map[string]string{}
+		if err := db.Ping(); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			resp["status"] = "error"
+			resp["db"] = "disconnected"
+		} else {
+			resp["status"] = "ok"
+			resp["db"] = "connected"
+		}
+		json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// loggingMiddleware logs method, path, status, and duration for each request.
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rw, r)
+		slog.Info("request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", rw.status,
+			"duration_ms", time.Since(start).Milliseconds(),
+		)
+	})
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.status = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func run() error {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	dbURL := os.Getenv("TURSO_DATABASE_URL")
+	dbToken := os.Getenv("TURSO_AUTH_TOKEN")
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+
+	db, err := openDB(dbURL, dbToken)
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer db.Close()
+
+	slog.Info("database connected", "url", dbURL)
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/health", healthHandler(db))
+
+	srv := &http.Server{
+		Addr:    ":" + port,
+		Handler: loggingMiddleware(mux),
+	}
+
+	// Graceful shutdown
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		slog.Info("server starting", "port", port)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("server error", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	sig := <-done
+	slog.Info("shutdown signal received", "signal", sig.String())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		return fmt.Errorf("server shutdown error: %w", err)
+	}
+
+	slog.Info("server stopped gracefully")
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error("fatal", "error", err)
+		os.Exit(1)
+	}
+}

--- a/apps/server/main_test.go
+++ b/apps/server/main_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// stubPinger implements the pinger interface for testing.
+type stubPinger struct {
+	err error
+}
+
+func (s *stubPinger) Ping() error { return s.err }
+
+func TestHealthHandler_DBConnected(t *testing.T) {
+	handler := healthHandler(&stubPinger{err: nil})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("expected status=ok, got %q", body["status"])
+	}
+	if body["db"] != "connected" {
+		t.Errorf("expected db=connected, got %q", body["db"])
+	}
+}
+
+func TestLoggingMiddleware(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	slog.SetDefault(logger)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := loggingMiddleware(inner)
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	logOutput := buf.String()
+	for _, want := range []string{`"method":"GET"`, `"path":"/api/health"`, `"status":200`} {
+		if !strings.Contains(logOutput, want) {
+			t.Errorf("log missing %s, got: %s", want, logOutput)
+		}
+	}
+}
+
+func TestLoggingMiddleware_CapturesStatus(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	slog.SetDefault(logger)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	handler := loggingMiddleware(inner)
+	req := httptest.NewRequest(http.MethodPost, "/missing", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, `"status":404`) {
+		t.Errorf("expected status 404 in log, got: %s", logOutput)
+	}
+}
+
+func TestHealthHandler_DBDisconnected(t *testing.T) {
+	handler := healthHandler(&stubPinger{err: errDBDown})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if body["status"] != "error" {
+		t.Errorf("expected status=error, got %q", body["status"])
+	}
+	if body["db"] != "disconnected" {
+		t.Errorf("expected db=disconnected, got %q", body["db"])
+	}
+}


### PR DESCRIPTION
Closes #102

Implemented by agent `be-20260414-1014081`.

## Changes
- `apps/server/main.go` — net/http server with `GET /api/health`, graceful shutdown (SIGINT/SIGTERM), structured JSON logging via `log/slog`
- `apps/server/db.go` — Turso/LibSQL connection via `database/sql` + libsql driver
- `apps/server/main_test.go` — 4 unit tests (health 200/503, logging middleware, status capture)
- `apps/server/Dockerfile` — Multi-stage build (golang:1.22-alpine → alpine:latest)
- `apps/server/fly.toml` — Fly.io config with health check at `/api/health`