### PR TITLE
[be-20260414-1014081] Auth system — login/refresh/logout/me + RBAC + tenant + rate limit (in-memory stub)

### DIFF
--- a/apps/server/cmd/api/main.go
+++ b/apps/server/cmd/api/main.go
@@ -14,10 +14,13 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/auth"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/blacklist"
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/db"
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/health"
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/otel"
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/router"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/store"
 )
 
 func main() {
@@ -65,9 +68,29 @@ func run() error {
 		slog.Warn("DATABASE_URL not set — /api/health will report not_configured")
 	}
 
+	// Auth deps — gracefully degrade when JWT keys aren't provided so local
+	// dev can iterate on non-auth endpoints without generating a keypair.
+	deps := router.Deps{DB: conn, CookieSec: envDefault("COOKIE_SECURE", "") != ""}
+	if priv, pub := os.Getenv("JWT_PRIVATE_KEY"), os.Getenv("JWT_PUBLIC_KEY"); priv != "" && pub != "" {
+		kp, err := auth.LoadKeyPair(priv, pub)
+		if err != nil {
+			return err
+		}
+		users, err := store.NewMemoryUserRepo()
+		if err != nil {
+			return err
+		}
+		deps.KP = kp
+		deps.Users = users
+		deps.Blacklist = blacklist.NewMemory()
+		slog.Info("auth endpoints enabled", "seeded_users", 3)
+	} else {
+		slog.Warn("JWT_PRIVATE_KEY/JWT_PUBLIC_KEY not set — /api/auth/* endpoints disabled")
+	}
+
 	srv := &http.Server{
 		Addr:         ":" + port,
-		Handler:      router.New(conn),
+		Handler:      router.NewWithDeps(deps),
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}

--- a/apps/server/go.mod
+++ b/apps/server/go.mod
@@ -10,6 +10,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	golang.org/x/crypto v0.49.0
 )
 
 require (

--- a/apps/server/go.sum
+++ b/apps/server/go.sum
@@ -57,6 +57,8 @@ go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpu
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
+golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
 golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/apps/server/internal/auth/refresh.go
+++ b/apps/server/internal/auth/refresh.go
@@ -1,0 +1,88 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// RefreshExpDuration is the refresh token TTL. Longer than access token
+// because refresh is always paired with blacklist revocation checks.
+const RefreshExpDuration = 7 * 24 * time.Hour
+
+const refreshTyp = "refresh"
+
+// RefreshClaims is the payload of a refresh JWT. It intentionally carries
+// fewer fields than access Claims — never use it to authorize API calls.
+type RefreshClaims struct {
+	Sub      string `json:"sub"`
+	TenantID string `json:"tenant_id"`
+	IAT      int64  `json:"iat"`
+	EXP      int64  `json:"exp"`
+	JTI      string `json:"jti"`
+	Typ      string `json:"typ"` // always "refresh"
+}
+
+func (c RefreshClaims) GetExpirationTime() (*jwt.NumericDate, error) {
+	return jwt.NewNumericDate(time.Unix(c.EXP, 0)), nil
+}
+func (c RefreshClaims) GetIssuedAt() (*jwt.NumericDate, error) {
+	return jwt.NewNumericDate(time.Unix(c.IAT, 0)), nil
+}
+func (c RefreshClaims) GetNotBefore() (*jwt.NumericDate, error) { return nil, nil }
+func (c RefreshClaims) GetIssuer() (string, error)              { return "", nil }
+func (c RefreshClaims) GetSubject() (string, error)             { return c.Sub, nil }
+func (c RefreshClaims) GetAudience() (jwt.ClaimStrings, error)  { return nil, nil }
+
+// NewRefreshClaims builds refresh claims with standard TTL and a fresh JTI.
+func NewRefreshClaims(sub, tenantID string) RefreshClaims {
+	now := time.Now()
+	return RefreshClaims{
+		Sub:      sub,
+		TenantID: tenantID,
+		IAT:      now.Unix(),
+		EXP:      now.Add(RefreshExpDuration).Unix(),
+		JTI:      newJTI(),
+		Typ:      refreshTyp,
+	}
+}
+
+// SignRefresh signs a refresh token with the same keypair as access tokens.
+// The distinction is carried in the Typ field — verifiers must assert it.
+func (kp *KeyPair) SignRefresh(c RefreshClaims) (string, error) {
+	c.Typ = refreshTyp
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, c)
+	signed, err := tok.SignedString(kp.priv)
+	if err != nil {
+		return "", fmt.Errorf("sign refresh: %w", err)
+	}
+	return signed, nil
+}
+
+// VerifyRefresh parses a refresh token and asserts Typ == "refresh".
+func (kp *KeyPair) VerifyRefresh(tokenStr string) (*RefreshClaims, error) {
+	var c RefreshClaims
+	_, err := jwt.ParseWithClaims(
+		tokenStr,
+		&c,
+		func(t *jwt.Token) (any, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+				return nil, ErrUnexpectedAlg
+			}
+			return kp.pub, nil
+		},
+		jwt.WithValidMethods([]string{"RS256"}),
+	)
+	if err != nil {
+		if errors.Is(err, jwt.ErrTokenExpired) {
+			return nil, ErrTokenExpired
+		}
+		return nil, fmt.Errorf("%w: %v", ErrTokenInvalid, err)
+	}
+	if c.Typ != refreshTyp {
+		return nil, fmt.Errorf("%w: not a refresh token", ErrTokenInvalid)
+	}
+	return &c, nil
+}

--- a/apps/server/internal/auth/refresh_test.go
+++ b/apps/server/internal/auth/refresh_test.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRefresh_SignVerifyRoundTrip(t *testing.T) {
+	priv, pub := makePEMs(t)
+	kp, _ := LoadKeyPair(priv, pub)
+
+	c := NewRefreshClaims("user-1", "tenant-1")
+	tok, err := kp.SignRefresh(c)
+	if err != nil {
+		t.Fatalf("SignRefresh: %v", err)
+	}
+	got, err := kp.VerifyRefresh(tok)
+	if err != nil {
+		t.Fatalf("VerifyRefresh: %v", err)
+	}
+	if got.Sub != "user-1" || got.TenantID != "tenant-1" || got.Typ != "refresh" || got.JTI == "" {
+		t.Errorf("claims round-trip: %+v", got)
+	}
+}
+
+func TestRefresh_RejectsAccessTokenAsRefresh(t *testing.T) {
+	priv, pub := makePEMs(t)
+	kp, _ := LoadKeyPair(priv, pub)
+
+	c := NewClaims("user-1", "tenant-1", []string{"admin"}, nil)
+	tok, _ := kp.Sign(c)
+
+	if _, err := kp.VerifyRefresh(tok); err == nil {
+		t.Error("expected VerifyRefresh to reject an access token (no typ='refresh')")
+	}
+}
+
+func TestRefresh_Expired(t *testing.T) {
+	priv, pub := makePEMs(t)
+	kp, _ := LoadKeyPair(priv, pub)
+
+	c := NewRefreshClaims("u", "t")
+	c.IAT = time.Now().Add(-10 * 24 * time.Hour).Unix()
+	c.EXP = time.Now().Add(-1 * time.Hour).Unix()
+
+	tok, _ := kp.SignRefresh(c)
+	_, err := kp.VerifyRefresh(tok)
+	if err == nil {
+		t.Error("expected expired error")
+	}
+}

--- a/apps/server/internal/authapi/handlers.go
+++ b/apps/server/internal/authapi/handlers.go
@@ -1,0 +1,262 @@
+// Package authapi implements the /api/auth/* HTTP endpoints.
+package authapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/auth"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/blacklist"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/httperr"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/middleware"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/store"
+)
+
+// RefreshCookieName is the HttpOnly cookie carrying the refresh JWT.
+const RefreshCookieName = "whitelabel_refresh"
+
+// loginRateKey builds a Limiter key for per-IP+email login.
+func loginRateKey(ip, email string) string { return "login:" + ip + "|" + email }
+
+// Handlers wires the four auth endpoints against the stores provided.
+type Handlers struct {
+	KP        *auth.KeyPair
+	Users     store.UserRepo
+	Blacklist blacklist.Store
+	Limiter   *middleware.Limiter // per-IP + per-email login limiter
+	CookieSec bool                // set Secure flag on refresh cookie (false in local dev)
+}
+
+// Mount attaches the endpoints to mux.
+func (h *Handlers) Mount(mux interface {
+	Post(pattern string, fn http.HandlerFunc)
+	Get(pattern string, fn http.HandlerFunc)
+}) {
+	mux.Post("/api/auth/login", h.login)
+	mux.Post("/api/auth/refresh", h.refresh)
+	mux.Post("/api/auth/logout", h.logout)
+	mux.Get("/api/auth/me", h.me)
+}
+
+// ----- Login -----
+
+type loginReq struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type userOut struct {
+	ID          string   `json:"id"`
+	Email       string   `json:"email"`
+	Name        string   `json:"name"`
+	TenantID    string   `json:"tenant_id"`
+	Roles       []string `json:"roles"`
+	Permissions []string `json:"permissions"`
+}
+
+type loginResp struct {
+	AccessToken     string  `json:"access_token"`
+	AccessExpiresIn int     `json:"access_expires_in"`
+	User            userOut `json:"user"`
+}
+
+func (h *Handlers) login(w http.ResponseWriter, r *http.Request) {
+	var req loginReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httperr.WriteFor(w, r, httperr.Validation(map[string]string{"body": "invalid JSON"}))
+		return
+	}
+	if req.Email == "" || req.Password == "" {
+		httperr.WriteFor(w, r, httperr.Validation(map[string]string{"email": "required", "password": "required"}))
+		return
+	}
+
+	// Per-IP + per-email rate limit BEFORE DB lookup so attackers can't
+	// probe existence via timing.
+	ip := middleware.ClientIP(r)
+	if ok, retry := h.Limiter.Allow(loginRateKey(ip, req.Email)); !ok {
+		middleware.WriteTooMany(w, r, retry)
+		return
+	}
+
+	// Uniform error — never reveal whether user exists.
+	invalid := httperr.Unauthorized("invalid credentials")
+
+	u, err := h.Users.FindByEmail(r.Context(), req.Email)
+	if err != nil {
+		// Still burn bcrypt time to equalise timings.
+		_ = bcrypt.CompareHashAndPassword([]byte("$2a$10$dummydummydummydummydummydummydummydummydummydummydu"), []byte(req.Password))
+		httperr.WriteFor(w, r, invalid)
+		return
+	}
+	if err := bcrypt.CompareHashAndPassword(u.PasswordHash, []byte(req.Password)); err != nil {
+		httperr.WriteFor(w, r, invalid)
+		return
+	}
+
+	access := auth.NewClaims(u.ID, u.TenantID, u.Roles, u.Permissions)
+	accessTok, err := h.KP.Sign(access)
+	if err != nil {
+		httperr.WriteFor(w, r, httperr.Internal(err))
+		return
+	}
+
+	refresh := auth.NewRefreshClaims(u.ID, u.TenantID)
+	refreshTok, err := h.KP.SignRefresh(refresh)
+	if err != nil {
+		httperr.WriteFor(w, r, httperr.Internal(err))
+		return
+	}
+
+	h.writeRefreshCookie(w, refreshTok, time.Unix(refresh.EXP, 0))
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(loginResp{
+		AccessToken:     accessTok,
+		AccessExpiresIn: int(auth.ExpDuration.Seconds()),
+		User:            userOutOf(u),
+	})
+}
+
+// ----- Refresh -----
+
+type refreshResp struct {
+	AccessToken     string `json:"access_token"`
+	AccessExpiresIn int    `json:"access_expires_in"`
+}
+
+func (h *Handlers) refresh(w http.ResponseWriter, r *http.Request) {
+	c, err := r.Cookie(RefreshCookieName)
+	if err != nil || c.Value == "" {
+		httperr.WriteFor(w, r, httperr.Unauthorized("missing refresh cookie"))
+		return
+	}
+	claims, err := h.KP.VerifyRefresh(c.Value)
+	if err != nil {
+		httperr.WriteFor(w, r, httperr.Unauthorized("invalid or expired refresh token"))
+		return
+	}
+	if revoked, _ := h.Blacklist.Contains(r.Context(), claims.JTI); revoked {
+		httperr.WriteFor(w, r, httperr.Unauthorized("refresh token revoked"))
+		return
+	}
+
+	u, err := h.Users.FindByID(r.Context(), claims.Sub)
+	if err != nil {
+		httperr.WriteFor(w, r, httperr.Unauthorized("user not found"))
+		return
+	}
+
+	// Rotate: revoke old JTI, issue new refresh cookie.
+	_ = h.Blacklist.Add(r.Context(), claims.JTI, time.Unix(claims.EXP, 0))
+
+	newRefresh := auth.NewRefreshClaims(u.ID, u.TenantID)
+	newRefreshTok, err := h.KP.SignRefresh(newRefresh)
+	if err != nil {
+		httperr.WriteFor(w, r, httperr.Internal(err))
+		return
+	}
+
+	access := auth.NewClaims(u.ID, u.TenantID, u.Roles, u.Permissions)
+	accessTok, err := h.KP.Sign(access)
+	if err != nil {
+		httperr.WriteFor(w, r, httperr.Internal(err))
+		return
+	}
+
+	h.writeRefreshCookie(w, newRefreshTok, time.Unix(newRefresh.EXP, 0))
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(refreshResp{
+		AccessToken:     accessTok,
+		AccessExpiresIn: int(auth.ExpDuration.Seconds()),
+	})
+}
+
+// ----- Logout -----
+
+func (h *Handlers) logout(w http.ResponseWriter, r *http.Request) {
+	c, err := r.Cookie(RefreshCookieName)
+	if err == nil && c.Value != "" {
+		if claims, err := h.KP.VerifyRefresh(c.Value); err == nil {
+			_ = h.Blacklist.Add(r.Context(), claims.JTI, time.Unix(claims.EXP, 0))
+		}
+	}
+	// Always clear the cookie client-side.
+	h.clearRefreshCookie(w)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ----- Me -----
+
+type meResp struct {
+	User        userOut  `json:"user"`
+	Roles       []string `json:"roles"`
+	Permissions []string `json:"permissions"`
+	TenantID    string   `json:"tenant_id"`
+}
+
+func (h *Handlers) me(w http.ResponseWriter, r *http.Request) {
+	c := middleware.ClaimsFromContext(r.Context())
+	if c == nil {
+		httperr.WriteFor(w, r, httperr.Unauthorized("missing claims"))
+		return
+	}
+	u, err := h.Users.FindByID(r.Context(), c.Sub)
+	if err != nil {
+		if errors.Is(err, store.ErrUserNotFound) {
+			httperr.WriteFor(w, r, httperr.Unauthorized("user not found"))
+			return
+		}
+		httperr.WriteFor(w, r, httperr.Internal(err))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(meResp{
+		User:        userOutOf(u),
+		Roles:       c.Roles,
+		Permissions: c.Permissions,
+		TenantID:    c.TenantID,
+	})
+}
+
+// ----- helpers -----
+
+func (h *Handlers) writeRefreshCookie(w http.ResponseWriter, tok string, expires time.Time) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     RefreshCookieName,
+		Value:    tok,
+		Path:     "/api/auth",
+		Expires:  expires,
+		HttpOnly: true,
+		Secure:   h.CookieSec,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (h *Handlers) clearRefreshCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     RefreshCookieName,
+		Value:    "",
+		Path:     "/api/auth",
+		Expires:  time.Unix(0, 0),
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   h.CookieSec,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func userOutOf(u *store.User) userOut {
+	return userOut{
+		ID: u.ID, Email: u.Email, Name: u.Name,
+		TenantID: u.TenantID, Roles: u.Roles, Permissions: u.Permissions,
+	}
+}

--- a/apps/server/internal/authapi/handlers.go
+++ b/apps/server/internal/authapi/handlers.go
@@ -31,16 +31,19 @@ type Handlers struct {
 	CookieSec bool                // set Secure flag on refresh cookie (false in local dev)
 }
 
-// Mount attaches the endpoints to mux.
+// Mount attaches the unauthenticated endpoints (login/refresh/logout) to mux.
+// /api/auth/me must be mounted separately under AuthContext — use MeHandler.
 func (h *Handlers) Mount(mux interface {
 	Post(pattern string, fn http.HandlerFunc)
-	Get(pattern string, fn http.HandlerFunc)
 }) {
 	mux.Post("/api/auth/login", h.login)
 	mux.Post("/api/auth/refresh", h.refresh)
 	mux.Post("/api/auth/logout", h.logout)
-	mux.Get("/api/auth/me", h.me)
 }
+
+// MeHandler returns the /api/auth/me handler so the router can wrap it in
+// AuthContext (Bearer-token required).
+func (h *Handlers) MeHandler() http.HandlerFunc { return h.me }
 
 // ----- Login -----
 

--- a/apps/server/internal/authapi/handlers_test.go
+++ b/apps/server/internal/authapi/handlers_test.go
@@ -260,3 +260,47 @@ func TestIntegration_LoginThenMe(t *testing.T) {
 		t.Fatalf("me status = %d", rec.Code)
 	}
 }
+
+func TestMeHandler_AccessorReturnsFunction(t *testing.T) {
+	h, _, _ := setup(t)
+	if h.MeHandler() == nil {
+		t.Error("MeHandler returned nil")
+	}
+}
+
+func TestMe_UserDeletedBetweenLoginAndMe_401(t *testing.T) {
+	_, r, kp := setup(t)
+	c := auth.NewClaims("user-ghost", "tenant-1", []string{"admin"}, store.PermsAdmin)
+	tok, _ := kp.Sign(c)
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/me-authed", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestRefresh_InvalidCookieValue_401(t *testing.T) {
+	_, r, _ := setup(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", nil)
+	req.AddCookie(&http.Cookie{Name: RefreshCookieName, Value: "not-a-jwt"})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestRefresh_UserDeletedBeforeRefresh_401(t *testing.T) {
+	_, r, kp := setup(t)
+	rc := auth.NewRefreshClaims("user-ghost", "tenant-1")
+	tok, _ := kp.SignRefresh(rc)
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", nil)
+	req.AddCookie(&http.Cookie{Name: RefreshCookieName, Value: tok})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}

--- a/apps/server/internal/authapi/handlers_test.go
+++ b/apps/server/internal/authapi/handlers_test.go
@@ -1,0 +1,262 @@
+package authapi
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/auth"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/blacklist"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/middleware"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/store"
+)
+
+func setup(t *testing.T) (*Handlers, *chi.Mux, *auth.KeyPair) {
+	t.Helper()
+	k, _ := rsa.GenerateKey(rand.Reader, 2048)
+	privDER, _ := x509.MarshalPKCS8PrivateKey(k)
+	pubDER, _ := x509.MarshalPKIXPublicKey(&k.PublicKey)
+	priv := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}))
+	pub := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
+	kp, _ := auth.LoadKeyPair(priv, pub)
+
+	users, _ := store.NewMemoryUserRepo()
+	h := &Handlers{
+		KP:        kp,
+		Users:     users,
+		Blacklist: blacklist.NewMemory(),
+		Limiter:   middleware.NewLimiter(100, time.Minute),
+		CookieSec: false,
+	}
+
+	r := chi.NewRouter()
+	h.Mount(r)
+	// /me needs AuthContext mounted
+	r.With(middleware.AuthContext(kp)).Get("/api/auth/me-authed", h.me)
+	return h, r, kp
+}
+
+func postJSON(r *chi.Mux, path string, body any) *httptest.ResponseRecorder {
+	buf, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestLogin_HappyPath(t *testing.T) {
+	_, r, _ := setup(t)
+	rec := postJSON(r, "/api/auth/login", loginReq{Email: "admin@test", Password: "password"})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp loginResp
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.AccessToken == "" {
+		t.Error("empty access_token")
+	}
+	if resp.User.Email != "admin@test" {
+		t.Errorf("user.email = %q", resp.User.Email)
+	}
+
+	// Check refresh cookie flags.
+	ck := rec.Result().Cookies()
+	if len(ck) != 1 || ck[0].Name != RefreshCookieName {
+		t.Fatalf("expected 1 refresh cookie, got %+v", ck)
+	}
+	c := ck[0]
+	if !c.HttpOnly {
+		t.Error("cookie HttpOnly = false")
+	}
+	if c.SameSite != http.SameSiteLaxMode {
+		t.Errorf("cookie SameSite = %v, want Lax", c.SameSite)
+	}
+	if c.Path != "/api/auth" {
+		t.Errorf("cookie Path = %q, want /api/auth", c.Path)
+	}
+}
+
+func TestLogin_WrongPassword_Uniform401(t *testing.T) {
+	_, r, _ := setup(t)
+	rec := postJSON(r, "/api/auth/login", loginReq{Email: "admin@test", Password: "wrong"})
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	var p map[string]any
+	_ = json.NewDecoder(rec.Body).Decode(&p)
+	if !strings.Contains(rec.Body.String()+"invalid credentials", "invalid credentials") {
+		t.Errorf("expected uniform 'invalid credentials' detail")
+	}
+}
+
+func TestLogin_UnknownEmail_Uniform401(t *testing.T) {
+	_, r, _ := setup(t)
+	rec := postJSON(r, "/api/auth/login", loginReq{Email: "nope@test", Password: "password"})
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestLogin_MissingFields_422(t *testing.T) {
+	_, r, _ := setup(t)
+	rec := postJSON(r, "/api/auth/login", loginReq{Email: "admin@test"})
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want 422", rec.Code)
+	}
+}
+
+func TestLogin_InvalidJSON_422(t *testing.T) {
+	_, r, _ := setup(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewReader([]byte("not-json")))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want 422", rec.Code)
+	}
+}
+
+func TestLogin_RateLimit_429(t *testing.T) {
+	k, _ := rsa.GenerateKey(rand.Reader, 2048)
+	privDER, _ := x509.MarshalPKCS8PrivateKey(k)
+	pubDER, _ := x509.MarshalPKIXPublicKey(&k.PublicKey)
+	priv := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}))
+	pub := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
+	kp, _ := auth.LoadKeyPair(priv, pub)
+	users, _ := store.NewMemoryUserRepo()
+
+	h := &Handlers{
+		KP: kp, Users: users, Blacklist: blacklist.NewMemory(),
+		Limiter: middleware.NewLimiter(2, time.Minute), CookieSec: false,
+	}
+	r := chi.NewRouter()
+	h.Mount(r)
+
+	// 2 allowed, 3rd should be 429.
+	for i := 0; i < 2; i++ {
+		rec := postJSON(r, "/api/auth/login", loginReq{Email: "admin@test", Password: "password"})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("hit %d status = %d", i, rec.Code)
+		}
+	}
+	rec := postJSON(r, "/api/auth/login", loginReq{Email: "admin@test", Password: "password"})
+	if rec.Code != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429", rec.Code)
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Error("missing Retry-After")
+	}
+}
+
+func TestRefresh_HappyPath_RotatesCookie(t *testing.T) {
+	_, r, _ := setup(t)
+	login := postJSON(r, "/api/auth/login", loginReq{Email: "admin@test", Password: "password"})
+	cookie := login.Result().Cookies()[0]
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp refreshResp
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if resp.AccessToken == "" {
+		t.Error("empty access_token")
+	}
+	// Must return a new refresh cookie distinct from the old.
+	new := rec.Result().Cookies()
+	if len(new) != 1 {
+		t.Fatalf("expected 1 rotated cookie, got %d", len(new))
+	}
+	if new[0].Value == cookie.Value {
+		t.Error("refresh cookie was not rotated")
+	}
+}
+
+func TestRefresh_AfterLogout_401(t *testing.T) {
+	_, r, _ := setup(t)
+	login := postJSON(r, "/api/auth/login", loginReq{Email: "admin@test", Password: "password"})
+	cookie := login.Result().Cookies()[0]
+
+	// Logout revokes the refresh JTI.
+	reqLogout := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	reqLogout.AddCookie(cookie)
+	recLogout := httptest.NewRecorder()
+	r.ServeHTTP(recLogout, reqLogout)
+	if recLogout.Code != http.StatusNoContent {
+		t.Fatalf("logout status = %d", recLogout.Code)
+	}
+
+	// Now try refresh with the revoked cookie.
+	reqR := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", nil)
+	reqR.AddCookie(cookie)
+	recR := httptest.NewRecorder()
+	r.ServeHTTP(recR, reqR)
+	if recR.Code != http.StatusUnauthorized {
+		t.Errorf("refresh-after-logout status = %d, want 401", recR.Code)
+	}
+}
+
+func TestRefresh_MissingCookie_401(t *testing.T) {
+	_, r, _ := setup(t)
+	rec := postJSON(r, "/api/auth/refresh", nil)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestMe_HappyPath(t *testing.T) {
+	_, r, kp := setup(t)
+	c := auth.NewClaims("user-admin", "tenant-1", []string{"admin"}, store.PermsAdmin)
+	tok, _ := kp.Sign(c)
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/me-authed", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp meResp
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if resp.User.Email != "admin@test" {
+		t.Errorf("user.email = %q", resp.User.Email)
+	}
+	if resp.TenantID != "tenant-1" {
+		t.Errorf("tenant_id = %q", resp.TenantID)
+	}
+}
+
+func TestIntegration_LoginThenMe(t *testing.T) {
+	_, r, _ := setup(t)
+
+	login := postJSON(r, "/api/auth/login", loginReq{Email: "editor@test", Password: "password"})
+	if login.Code != http.StatusOK {
+		t.Fatalf("login %d: %s", login.Code, login.Body.String())
+	}
+	var loginR loginResp
+	_ = json.NewDecoder(login.Body).Decode(&loginR)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/me-authed", nil)
+	req.Header.Set("Authorization", "Bearer "+loginR.AccessToken)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("me status = %d", rec.Code)
+	}
+}

--- a/apps/server/internal/blacklist/blacklist.go
+++ b/apps/server/internal/blacklist/blacklist.go
@@ -1,0 +1,46 @@
+// Package blacklist tracks revoked refresh-token JTIs.
+//
+// Phase 3 uses an in-memory sync.Map stub so we can ship without the
+// Cloudflare KV namespace. TODO(#N_KV): swap to Cloudflare KV when #138
+// provisioning lands.
+package blacklist
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Store is the minimal interface over the JTI blacklist.
+type Store interface {
+	// Add records jti as revoked until expiresAt. Safe to call repeatedly.
+	Add(ctx context.Context, jti string, expiresAt time.Time) error
+	// Contains returns true if jti has been revoked and the revocation
+	// hasn't expired.
+	Contains(ctx context.Context, jti string) (bool, error)
+}
+
+// Memory is a process-local Store backed by sync.Map. Good for Phase 3
+// stubs; NOT safe across serverless invocations.
+type Memory struct{ m sync.Map }
+
+// NewMemory returns an empty in-memory Store.
+func NewMemory() *Memory { return &Memory{} }
+
+func (m *Memory) Add(_ context.Context, jti string, expiresAt time.Time) error {
+	m.m.Store(jti, expiresAt)
+	return nil
+}
+
+func (m *Memory) Contains(_ context.Context, jti string) (bool, error) {
+	v, ok := m.m.Load(jti)
+	if !ok {
+		return false, nil
+	}
+	exp, _ := v.(time.Time)
+	if time.Now().After(exp) {
+		m.m.Delete(jti)
+		return false, nil
+	}
+	return true, nil
+}

--- a/apps/server/internal/blacklist/blacklist_test.go
+++ b/apps/server/internal/blacklist/blacklist_test.go
@@ -1,0 +1,37 @@
+package blacklist
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMemory_ContainsAfterAdd(t *testing.T) {
+	m := NewMemory()
+	exp := time.Now().Add(1 * time.Hour)
+	if err := m.Add(context.Background(), "jti-1", exp); err != nil {
+		t.Fatal(err)
+	}
+	ok, err := m.Contains(context.Background(), "jti-1")
+	if err != nil || !ok {
+		t.Errorf("expected Contains true, got %v, err=%v", ok, err)
+	}
+}
+
+func TestMemory_NotContainsUnknown(t *testing.T) {
+	m := NewMemory()
+	ok, err := m.Contains(context.Background(), "jti-nope")
+	if err != nil || ok {
+		t.Errorf("expected Contains false, got %v, err=%v", ok, err)
+	}
+}
+
+func TestMemory_ExpiredEntryEvictsOnRead(t *testing.T) {
+	m := NewMemory()
+	// Expired 1s ago.
+	_ = m.Add(context.Background(), "jti-expired", time.Now().Add(-1*time.Second))
+	ok, _ := m.Contains(context.Background(), "jti-expired")
+	if ok {
+		t.Error("expired entry still reported contained")
+	}
+}

--- a/apps/server/internal/middleware/authctx.go
+++ b/apps/server/internal/middleware/authctx.go
@@ -1,0 +1,48 @@
+// Package middleware exposes auth/rbac/tenant/ratelimit chi middleware.
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/auth"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/httperr"
+)
+
+type claimsCtxKey struct{}
+
+// WithClaims stores Claims on the context.
+func WithClaims(ctx context.Context, c *auth.Claims) context.Context {
+	return context.WithValue(ctx, claimsCtxKey{}, c)
+}
+
+// ClaimsFromContext returns the Claims attached by AuthContext, or nil.
+func ClaimsFromContext(ctx context.Context) *auth.Claims {
+	c, _ := ctx.Value(claimsCtxKey{}).(*auth.Claims)
+	return c
+}
+
+// AuthContext returns chi middleware that parses the incoming Authorization
+// bearer token with kp, puts the Claims on the request context on success,
+// or responds with 401 + RFC 7807 on failure.
+//
+// Does NOT enforce permissions — use RequirePermission for that.
+func AuthContext(kp *auth.KeyPair) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hdr := r.Header.Get("Authorization")
+			if !strings.HasPrefix(hdr, "Bearer ") {
+				httperr.WriteFor(w, r, httperr.Unauthorized("missing bearer token"))
+				return
+			}
+			tok := strings.TrimPrefix(hdr, "Bearer ")
+			claims, err := kp.Verify(tok)
+			if err != nil {
+				httperr.WriteFor(w, r, httperr.Unauthorized("invalid or expired token"))
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(WithClaims(r.Context(), claims)))
+		})
+	}
+}

--- a/apps/server/internal/middleware/authctx_test.go
+++ b/apps/server/internal/middleware/authctx_test.go
@@ -1,0 +1,85 @@
+package middleware
+
+import (
+	"encoding/pem"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/auth"
+)
+
+func makeKP(t *testing.T) *auth.KeyPair {
+	t.Helper()
+	k, _ := rsa.GenerateKey(rand.Reader, 2048)
+	privDER, _ := x509.MarshalPKCS8PrivateKey(k)
+	pubDER, _ := x509.MarshalPKIXPublicKey(&k.PublicKey)
+	priv := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}))
+	pub := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
+	kp, err := auth.LoadKeyPair(priv, pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return kp
+}
+
+func TestAuthContext_MissingHeader_401(t *testing.T) {
+	kp := makeKP(t)
+	h := AuthContext(kp)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next should not run")
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/me", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+	if rec.Header().Get("Content-Type") != "application/problem+json" {
+		t.Errorf("Content-Type = %q", rec.Header().Get("Content-Type"))
+	}
+}
+
+func TestAuthContext_InvalidToken_401(t *testing.T) {
+	kp := makeKP(t)
+	h := AuthContext(kp)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next should not run")
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/me", nil)
+	req.Header.Set("Authorization", "Bearer nope.nope.nope")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestAuthContext_ValidToken_PutsClaimsOnContext(t *testing.T) {
+	kp := makeKP(t)
+	c := auth.NewClaims("u1", "t1", []string{"admin"}, []string{"users:read"})
+	tok, _ := kp.Sign(c)
+
+	var seen *auth.Claims
+	h := AuthContext(kp)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = ClaimsFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/me", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if seen == nil || seen.Sub != "u1" || seen.TenantID != "t1" {
+		t.Errorf("claims on context: %+v", seen)
+	}
+	// Sanity: body is empty (handler wrote 200 with nothing).
+	if rec.Body.Len() != 0 {
+		_ = json.NewDecoder(rec.Body).Decode(&map[string]any{})
+	}
+}

--- a/apps/server/internal/middleware/ratelimit.go
+++ b/apps/server/internal/middleware/ratelimit.go
@@ -1,0 +1,109 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/httperr"
+)
+
+// bucket is a very small fixed-window counter keyed by some identifier.
+// Zero-value is usable.
+type bucket struct {
+	mu     sync.Mutex
+	count  int
+	window time.Time
+}
+
+// Limiter is a fixed-window, in-memory rate limiter. TODO(#N_KV): swap to
+// Cloudflare KV when #138 lands so preview + prod can share counters.
+type Limiter struct {
+	perWindow int
+	window    time.Duration
+	buckets   sync.Map // map[string]*bucket
+}
+
+// NewLimiter returns a Limiter that allows perWindow hits per window per key.
+func NewLimiter(perWindow int, window time.Duration) *Limiter {
+	return &Limiter{perWindow: perWindow, window: window}
+}
+
+// allow atomically increments the counter for key; returns (ok, retryAfter).
+func (l *Limiter) allow(key string, now time.Time) (bool, time.Duration) {
+	v, _ := l.buckets.LoadOrStore(key, &bucket{})
+	b := v.(*bucket)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if now.After(b.window) {
+		b.count = 0
+		b.window = now.Add(l.window)
+	}
+	if b.count >= l.perWindow {
+		return false, time.Until(b.window)
+	}
+	b.count++
+	return true, 0
+}
+
+// ClientIP extracts the client IP, honouring the first entry in
+// X-Forwarded-For when present (Vercel / CDN proxy). Exported so handlers
+// can key bespoke limiters (e.g. per-email on login).
+func ClientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if i := strings.Index(xff, ","); i >= 0 {
+			return strings.TrimSpace(xff[:i])
+		}
+		return strings.TrimSpace(xff)
+	}
+	// RemoteAddr is "host:port".
+	if i := strings.LastIndex(r.RemoteAddr, ":"); i >= 0 {
+		return r.RemoteAddr[:i]
+	}
+	return r.RemoteAddr
+}
+
+// PerIP returns middleware that rate-limits per client IP.
+func (l *Limiter) PerIP(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ok, retry := l.allow("ip:"+ClientIP(r), time.Now())
+		if !ok {
+			tooMany(w, r, retry)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Allow records a hit under the composite key (caller-supplied, e.g.
+// "email:alice@test") and returns (ok, retryAfter). Handlers that want
+// two-dimensional limiting (IP + email) call this directly.
+func (l *Limiter) Allow(key string) (bool, time.Duration) {
+	return l.allow(key, time.Now())
+}
+
+// tooMany writes 429 + Retry-After + RFC 7807 body.
+func tooMany(w http.ResponseWriter, r *http.Request, retry time.Duration) {
+	secs := int(retry.Seconds())
+	if secs < 1 {
+		secs = 1
+	}
+	w.Header().Set("Retry-After", strconv.Itoa(secs))
+	p := &httperr.Problem{
+		Type:   "about:blank",
+		Title:  "Too Many Requests",
+		Status: http.StatusTooManyRequests,
+		Detail: "Rate limit exceeded. Retry after " + strconv.Itoa(secs) + "s.",
+	}
+	httperr.WriteFor(w, r, p)
+}
+
+// WriteTooMany exposes the 429-writing helper so handlers can emit it after
+// a custom allow() call.
+func WriteTooMany(w http.ResponseWriter, r *http.Request, retry time.Duration) {
+	tooMany(w, r, retry)
+}

--- a/apps/server/internal/middleware/ratelimit_test.go
+++ b/apps/server/internal/middleware/ratelimit_test.go
@@ -1,0 +1,84 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestLimiter_Allow_WithinWindow(t *testing.T) {
+	l := NewLimiter(3, 1*time.Minute)
+	for i := 0; i < 3; i++ {
+		ok, _ := l.Allow("k")
+		if !ok {
+			t.Fatalf("hit %d denied, expected allowed", i)
+		}
+	}
+	ok, retry := l.Allow("k")
+	if ok {
+		t.Fatal("4th hit allowed, expected denied")
+	}
+	if retry <= 0 {
+		t.Errorf("retry = %v, want > 0", retry)
+	}
+}
+
+func TestLimiter_PerIP_429WithRetryAfter(t *testing.T) {
+	l := NewLimiter(1, 1*time.Minute)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := l.PerIP(next)
+
+	req1 := httptest.NewRequest(http.MethodGet, "/api/x", nil)
+	req1.RemoteAddr = "1.1.1.1:9999"
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first hit status = %d, want 200", rec1.Code)
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/api/x", nil)
+	req2.RemoteAddr = "1.1.1.1:9999"
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second hit status = %d, want 429", rec2.Code)
+	}
+	ra := rec2.Header().Get("Retry-After")
+	if n, err := strconv.Atoi(ra); err != nil || n < 1 {
+		t.Errorf("Retry-After = %q, want >=1 integer", ra)
+	}
+	if rec2.Header().Get("Content-Type") != "application/problem+json" {
+		t.Errorf("Content-Type = %q", rec2.Header().Get("Content-Type"))
+	}
+}
+
+func TestLimiter_SeparateKeysDoNotShare(t *testing.T) {
+	l := NewLimiter(1, 1*time.Minute)
+	if ok, _ := l.Allow("a"); !ok {
+		t.Fatal("first 'a' denied")
+	}
+	if ok, _ := l.Allow("b"); !ok {
+		t.Fatal("first 'b' denied")
+	}
+}
+
+func TestClientIP_XForwardedFor(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "9.9.9.9, 10.0.0.1")
+	req.RemoteAddr = "127.0.0.1:5555"
+	if got := ClientIP(req); got != "9.9.9.9" {
+		t.Errorf("ClientIP = %q, want 9.9.9.9", got)
+	}
+}
+
+func TestClientIP_FallsBackToRemoteAddr(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "8.8.8.8:12345"
+	if got := ClientIP(req); got != "8.8.8.8" {
+		t.Errorf("ClientIP = %q, want 8.8.8.8", got)
+	}
+}

--- a/apps/server/internal/middleware/rbac.go
+++ b/apps/server/internal/middleware/rbac.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/httperr"
+)
+
+// RequirePermission returns middleware that allows the request only if the
+// Claims on the context include perm. Must be mounted AFTER AuthContext.
+func RequirePermission(perm string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			c := ClaimsFromContext(r.Context())
+			if c == nil {
+				httperr.WriteFor(w, r, httperr.Unauthorized("no claims on context"))
+				return
+			}
+			for _, p := range c.Permissions {
+				if p == perm {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+			httperr.WriteFor(w, r, httperr.Forbidden("missing permission: "+perm))
+		})
+	}
+}

--- a/apps/server/internal/middleware/rbac_test.go
+++ b/apps/server/internal/middleware/rbac_test.go
@@ -1,0 +1,48 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/auth"
+)
+
+func TestRequirePermission_Pass(t *testing.T) {
+	c := auth.NewClaims("u", "t", []string{"admin"}, []string{"users:read"})
+	h := RequirePermission("users:read")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/users", nil).WithContext(WithClaims(context.Background(), &c))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestRequirePermission_Missing_403(t *testing.T) {
+	c := auth.NewClaims("u", "t", []string{"viewer"}, []string{"items:read"})
+	h := RequirePermission("users:write")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next should not run")
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/api/users", nil).WithContext(WithClaims(context.Background(), &c))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestRequirePermission_NoClaims_401(t *testing.T) {
+	h := RequirePermission("any")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next should not run")
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}

--- a/apps/server/internal/middleware/tenant.go
+++ b/apps/server/internal/middleware/tenant.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/httperr"
+)
+
+type tenantCtxKey struct{}
+
+// WithTenantID stores tenant id on context (exported for handlers that want
+// to set it directly without going through middleware, e.g. tests).
+func WithTenantID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, tenantCtxKey{}, id)
+}
+
+// TenantIDFromContext returns the tenant id previously set by Tenant or
+// WithTenantID. The bool is false when unset. Repo layer will use this to
+// auto-inject WHERE tenant_id = $X.
+func TenantIDFromContext(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(tenantCtxKey{}).(string)
+	return id, ok && id != ""
+}
+
+// Tenant middleware pulls tenant_id from Claims (set by AuthContext) and
+// stores it on the request context. Must be mounted AFTER AuthContext.
+// Responds with 401 + RFC 7807 if Claims missing; 403 if tenant_id empty.
+func Tenant(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c := ClaimsFromContext(r.Context())
+		if c == nil {
+			httperr.WriteFor(w, r, httperr.Unauthorized("no claims on context"))
+			return
+		}
+		if c.TenantID == "" {
+			httperr.WriteFor(w, r, httperr.Forbidden("token has no tenant_id"))
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(WithTenantID(r.Context(), c.TenantID)))
+	})
+}

--- a/apps/server/internal/middleware/tenant_test.go
+++ b/apps/server/internal/middleware/tenant_test.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/auth"
+)
+
+func TestTenant_PutsIDOnContext(t *testing.T) {
+	c := auth.NewClaims("u", "tenant-acme", []string{"admin"}, nil)
+	var seen string
+	h := Tenant(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, ok := TenantIDFromContext(r.Context())
+		if !ok {
+			t.Error("tenant id not on context")
+		}
+		seen = id
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/x", nil).WithContext(WithClaims(context.Background(), &c))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if seen != "tenant-acme" {
+		t.Errorf("seen = %q, want tenant-acme", seen)
+	}
+}
+
+func TestTenant_NoClaims_401(t *testing.T) {
+	h := Tenant(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next should not run")
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestTenant_NoTenantID_403(t *testing.T) {
+	c := auth.NewClaims("u", "", []string{"admin"}, nil)
+	h := Tenant(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next should not run")
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/x", nil).WithContext(WithClaims(context.Background(), &c))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rec.Code)
+	}
+}

--- a/apps/server/internal/router/router.go
+++ b/apps/server/internal/router/router.go
@@ -9,27 +9,61 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/auth"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/authapi"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/blacklist"
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/health"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/middleware"
 	otelmw "github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/otel"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/store"
 )
+
+// Deps bundles the cross-cutting singletons the router needs.
+// Any field may be nil — the router degrades gracefully (auth routes
+// are only mounted when KP+Users+Blacklist are all provided).
+type Deps struct {
+	DB        health.Pinger
+	KP        *auth.KeyPair
+	Users     store.UserRepo
+	Blacklist blacklist.Store
+	CookieSec bool // Secure cookie flag — true in prod, false in local http
+}
 
 // New returns a chi.Mux wired with the request-logging middleware and the
 // /api/health endpoint. Passing a nil Pinger signals "DATABASE_URL unset" —
 // health responds with 503 + {"db":"not_configured"} (graceful degradation).
-//
-// Additional middleware mount points are reserved below for follow-up tasks;
-// do NOT implement them here.
 func New(db health.Pinger) *chi.Mux {
+	return NewWithDeps(Deps{DB: db})
+}
+
+// NewWithDeps is the full constructor. When auth deps are supplied, it
+// mounts the /api/auth/* endpoints (login/refresh/logout/me).
+func NewWithDeps(d Deps) *chi.Mux {
 	r := chi.NewRouter()
 
 	r.Use(otelmw.Middleware) // OpenTelemetry span + W3C traceparent propagation
 	r.Use(loggingMiddleware)
 	// TODO(#N_AUDIT): r.Use(audit.Middleware)   — audit log capture
-	// TODO(#N_TENANT): r.Use(tenant.Middleware) — JWT → tenant scoping
 
 	// /api/health is intentionally NOT behind auth middleware —
 	// external probes (Vercel, uptime monitors) must reach it.
-	r.Get("/api/health", health.Handler(db))
+	r.Get("/api/health", health.Handler(d.DB))
+
+	if d.KP != nil && d.Users != nil && d.Blacklist != nil {
+		// Login limiter: 5 req/min per (ip+email) composite key.
+		loginLimiter := middleware.NewLimiter(5, time.Minute)
+		h := &authapi.Handlers{
+			KP:        d.KP,
+			Users:     d.Users,
+			Blacklist: d.Blacklist,
+			Limiter:   loginLimiter,
+			CookieSec: d.CookieSec,
+		}
+		h.Mount(r)
+
+		// /api/auth/me sits behind AuthContext (Bearer JWT required).
+		r.With(middleware.AuthContext(d.KP)).Get("/api/auth/me", h.MeHandler())
+	}
 
 	return r
 }

--- a/apps/server/internal/router/router_test.go
+++ b/apps/server/internal/router/router_test.go
@@ -1,11 +1,20 @@
 package router
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/auth"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/blacklist"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/store"
 )
 
 type stubPinger struct{ err error }
@@ -46,5 +55,51 @@ func TestNew_UnknownRoute_404(t *testing.T) {
 	r.ServeHTTP(rec, req)
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestNewWithDeps_MountsAuthEndpoints(t *testing.T) {
+	k, _ := rsa.GenerateKey(rand.Reader, 2048)
+	privDER, _ := x509.MarshalPKCS8PrivateKey(k)
+	pubDER, _ := x509.MarshalPKIXPublicKey(&k.PublicKey)
+	priv := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}))
+	pub := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
+	kp, _ := auth.LoadKeyPair(priv, pub)
+	users, _ := store.NewMemoryUserRepo()
+
+	r := NewWithDeps(Deps{
+		DB:        &stubPinger{err: nil},
+		KP:        kp,
+		Users:     users,
+		Blacklist: blacklist.NewMemory(),
+	})
+
+	// POST /api/auth/login should exist (and succeed with seeded creds).
+	body, _ := json.Marshal(map[string]string{"email": "admin@test", "password": "password"})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("login status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	// GET /api/auth/me WITHOUT bearer → 401 (AuthContext catches it).
+	reqMe := httptest.NewRequest(http.MethodGet, "/api/auth/me", nil)
+	recMe := httptest.NewRecorder()
+	r.ServeHTTP(recMe, reqMe)
+	if recMe.Code != http.StatusUnauthorized {
+		t.Errorf("me (no bearer) status = %d, want 401", recMe.Code)
+	}
+}
+
+func TestNewWithDeps_AuthDisabledWhenKeysMissing(t *testing.T) {
+	r := NewWithDeps(Deps{DB: &stubPinger{err: nil}})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 when auth deps missing", rec.Code)
 	}
 }

--- a/apps/server/internal/store/memory.go
+++ b/apps/server/internal/store/memory.go
@@ -1,0 +1,92 @@
+// Package store provides user / tenant repositories.
+//
+// Phase 3 ships with an in-memory stub so the auth system can land before
+// the Phase 4 pgx layer is ready. The interfaces are designed to be drop-in
+// replaced by a real Postgres impl in Phase 6.
+package store
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+var ErrUserNotFound = errors.New("user not found")
+
+// User is the domain entity. IDs are ULIDs in production; simple strings here.
+type User struct {
+	ID           string
+	Email        string
+	Name         string
+	PasswordHash []byte
+	TenantID     string
+	Roles        []string
+	Permissions  []string
+}
+
+// UserRepo is the contract the auth handlers require. Phase 4 adds a pgx impl.
+type UserRepo interface {
+	FindByEmail(ctx context.Context, email string) (*User, error)
+	FindByID(ctx context.Context, id string) (*User, error)
+}
+
+// Permissions for each seeded role. Centralised so middleware and tests agree.
+var (
+	PermsAdmin  = []string{"users:read", "users:write", "items:read", "items:write", "audit:read"}
+	PermsEditor = []string{"items:read", "items:write", "users:read"}
+	PermsViewer = []string{"items:read", "users:read"}
+)
+
+// MemoryUserRepo is a trivial map-backed repo with three seeded users.
+type MemoryUserRepo struct{ byEmail map[string]*User }
+
+// NewMemoryUserRepo returns a repo pre-loaded with admin/editor/viewer users,
+// all with password "password" (bcrypt-hashed at cost=10 for dev).
+func NewMemoryUserRepo() (*MemoryUserRepo, error) {
+	pw, err := bcrypt.GenerateFromPassword([]byte("password"), 10)
+	if err != nil {
+		return nil, err
+	}
+	users := []*User{
+		{
+			ID: "user-admin", Email: "admin@test", Name: "Admin",
+			PasswordHash: pw, TenantID: "tenant-1",
+			Roles: []string{"admin"}, Permissions: PermsAdmin,
+		},
+		{
+			ID: "user-editor", Email: "editor@test", Name: "Editor",
+			PasswordHash: pw, TenantID: "tenant-1",
+			Roles: []string{"editor"}, Permissions: PermsEditor,
+		},
+		{
+			ID: "user-viewer", Email: "viewer@test", Name: "Viewer",
+			PasswordHash: pw, TenantID: "tenant-1",
+			Roles: []string{"viewer"}, Permissions: PermsViewer,
+		},
+	}
+
+	m := &MemoryUserRepo{byEmail: make(map[string]*User, len(users))}
+	for _, u := range users {
+		m.byEmail[strings.ToLower(u.Email)] = u
+	}
+	return m, nil
+}
+
+func (m *MemoryUserRepo) FindByEmail(_ context.Context, email string) (*User, error) {
+	u, ok := m.byEmail[strings.ToLower(email)]
+	if !ok {
+		return nil, ErrUserNotFound
+	}
+	return u, nil
+}
+
+func (m *MemoryUserRepo) FindByID(_ context.Context, id string) (*User, error) {
+	for _, u := range m.byEmail {
+		if u.ID == id {
+			return u, nil
+		}
+	}
+	return nil, ErrUserNotFound
+}

--- a/apps/server/internal/store/memory_test.go
+++ b/apps/server/internal/store/memory_test.go
@@ -1,0 +1,49 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestMemoryUserRepo_Seeded(t *testing.T) {
+	m, err := NewMemoryUserRepo()
+	if err != nil {
+		t.Fatalf("NewMemoryUserRepo: %v", err)
+	}
+	for _, email := range []string{"admin@test", "editor@test", "viewer@test"} {
+		u, err := m.FindByEmail(context.Background(), email)
+		if err != nil {
+			t.Errorf("FindByEmail(%q): %v", email, err)
+			continue
+		}
+		if err := bcrypt.CompareHashAndPassword(u.PasswordHash, []byte("password")); err != nil {
+			t.Errorf("%s: password 'password' does not verify: %v", email, err)
+		}
+	}
+}
+
+func TestMemoryUserRepo_UnknownEmail(t *testing.T) {
+	m, _ := NewMemoryUserRepo()
+	_, err := m.FindByEmail(context.Background(), "nobody@test")
+	if !errors.Is(err, ErrUserNotFound) {
+		t.Errorf("err = %v, want ErrUserNotFound", err)
+	}
+}
+
+func TestMemoryUserRepo_EmailCaseInsensitive(t *testing.T) {
+	m, _ := NewMemoryUserRepo()
+	if _, err := m.FindByEmail(context.Background(), "ADMIN@test"); err != nil {
+		t.Errorf("expected case-insensitive lookup, got %v", err)
+	}
+}
+
+func TestMemoryUserRepo_FindByID(t *testing.T) {
+	m, _ := NewMemoryUserRepo()
+	u, err := m.FindByID(context.Background(), "user-admin")
+	if err != nil || u.Email != "admin@test" {
+		t.Errorf("FindByID: u=%+v err=%v", u, err)
+	}
+}


### PR DESCRIPTION
Closes #148.

Implemented by agent `be-20260414-1014081`.

## Changes

### New packages
- `internal/blacklist` — `sync.Map`-backed JTI blacklist, auto-evicts on expired read. `TODO(#N_KV): swap to CF KV`.
- `internal/store` — `UserRepo` interface + `MemoryUserRepo` with 3 seeded users (admin/editor/viewer, bcrypt "password"). Phase 4 pgx impl drops in.
- `internal/middleware` — `AuthContext` (Bearer → Claims on context), `RequirePermission`, `Tenant`, `Limiter` (per-IP + per-key, 429 + Retry-After + problem+json body).
- `internal/authapi` — four HTTP handlers: login, refresh, logout, me. Uniform 401 on bad credentials; refresh cookie `HttpOnly`+`Secure`+`SameSite=Lax`+`Path=/api/auth`; refresh rotates JTI + blacklists old; bcrypt-time equalised even on unknown email.

### Extended
- `internal/auth/refresh.go` — `RefreshClaims` (shorter payload, `typ="refresh"`), `SignRefresh`/`VerifyRefresh`. 7-day TTL.
- `internal/router/router.go` — `NewWithDeps(Deps{DB, KP, Users, Blacklist, CookieSec})`; mounts `/api/auth/*` when auth deps present; `/api/auth/me` sits behind `AuthContext`.
- `cmd/api/main.go` — reads `JWT_PRIVATE_KEY`/`JWT_PUBLIC_KEY` env; auth endpoints are disabled gracefully when keys missing.

## Validation
- `go vet ./...` clean, `go build ./...` clean
- `go test -race -count=1 ./...` all green
- Coverage (handler/middleware packages): authapi **87.0%**, middleware **94.4%**, auth 83.1%, blacklist 100%, store 87.5% — all ≥ 80%
- Live smoke (RS256 keys from `cmd/keygen`, no DB):
  - `POST /api/auth/login` admin@test/password → 200 + access_token + refresh cookie with full flag set
  - `GET /api/auth/me` with bearer → 200 + user/roles/permissions/tenant_id
  - Wrong password → 401 `application/problem+json` "invalid credentials" (uniform — no enumeration)
  - Missing Authorization → 401 "missing bearer token"

Problem shape matches `docs/api/openapi.yaml` from #123.