### PR TITLE
[ops-20260415-1506114] OPS: CI migrate jobs + Neon branch mgmt + rollback docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,39 @@ jobs:
           cache-dependency-path: apps/server/go.sum
       - run: go vet ./...
       - run: go test -race -count=1 ./...
+
+  migrate:
+    name: migrate (prod)
+    needs: [go-test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: apps/server/go.mod
+          cache-dependency-path: apps/server/go.sum
+      - run: go run ./cmd/migrate up
+        env:
+          DATABASE_URL: ${{ secrets.NEON_PROD_URL }}
+
+  migrate-preview:
+    name: migrate (preview)
+    needs: [go-test]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: apps/server/go.mod
+          cache-dependency-path: apps/server/go.sum
+      - run: go run ./cmd/migrate up
+        env:
+          DATABASE_URL: ${{ secrets.NEON_PREVIEW_URL }}

--- a/docs/ops/migration-rollback.md
+++ b/docs/ops/migration-rollback.md
@@ -1,0 +1,76 @@
+# Migration Rollback
+
+## When to Use `.down.sql`
+
+Safe for schema-only changes with no data loss risk:
+
+- Adding a column (down = drop column, no user data in it yet)
+- Creating a new table (down = drop table)
+- Adding an index (down = drop index)
+
+Run:
+
+```bash
+DATABASE_URL="<target-url>" go run ./cmd/migrate down 1
+```
+
+## When to Intervene Manually
+
+Required for data-destructive changes or production recovery:
+
+- Dropping a column that has user data
+- Renaming a table or column (down.sql can't restore lost references)
+- Any migration that ran partially (dirty state)
+- Production incident where rollback timing matters
+
+## Production Rollback Procedure
+
+### 1. Pause Deploys
+
+Disable auto-deploy on Vercel to prevent new code from running against the rolled-back schema.
+
+```bash
+# In Vercel dashboard: Settings → Git → Disable auto-deploy
+# Or cancel any in-flight deployments
+```
+
+### 2. Run Rollback
+
+```bash
+DATABASE_URL="$NEON_PROD_URL" go run ./cmd/migrate down 1
+```
+
+To roll back multiple steps:
+
+```bash
+DATABASE_URL="$NEON_PROD_URL" go run ./cmd/migrate down <N>
+```
+
+### 3. Verify
+
+```bash
+DATABASE_URL="$NEON_PROD_URL" go run ./cmd/migrate version
+```
+
+Confirm the schema version matches the code that's currently deployed.
+
+### 4. Resume Deploys
+
+Re-enable auto-deploy on Vercel. If the rollback was triggered by a bad merge, revert the merge commit first.
+
+## Who to Notify
+
+- **ARCH agent**: route an issue with `status:blocked` describing the incident
+- **Repo owner** (@liyoclaw1242): for any production data loss or extended downtime
+- **Stakeholder reviewers**: see project memory for handles per repo
+
+## Dirty State Recovery
+
+If a migration failed partway (golang-migrate marks the version as "dirty"):
+
+```bash
+# Force the version to the last known-good migration number
+DATABASE_URL="<url>" go run ./cmd/migrate force <version>
+```
+
+Then re-run or roll back from the clean state.

--- a/docs/ops/neon-branch-management.md
+++ b/docs/ops/neon-branch-management.md
@@ -1,0 +1,55 @@
+# Neon Branch Management
+
+## Branch Layout
+
+| Neon Branch | Environment | Vercel Secret | Purpose |
+|-------------|-------------|---------------|---------|
+| `main` | Production | `NEON_PROD_URL` | Live data, migrated on push to main |
+| `preview` | Preview / Dev | `NEON_PREVIEW_URL` | PR preview deploys + local dev |
+| `dev` | Development | `NEON_DEV_URL` | Shared dev experiments (optional) |
+
+## Reset Preview Branch
+
+Use when preview data is stale or migrations drifted from main.
+
+```bash
+# Via Neon dashboard: Branches → preview → Reset from parent
+# Or via CLI (if neonctl is installed):
+neonctl branches reset preview --parent
+```
+
+After reset, re-run migrations against the preview branch:
+
+```bash
+DATABASE_URL="<NEON_PREVIEW_URL>" go run ./cmd/migrate up
+```
+
+## Fork for Isolated Migration Testing
+
+Create a throwaway branch from main to test a migration before merging:
+
+```bash
+neonctl branches create --name test-migration-123 --parent main
+```
+
+Run the migration against the fork:
+
+```bash
+DATABASE_URL="<fork-connection-string>" go run ./cmd/migrate up
+```
+
+Verify, then delete:
+
+```bash
+neonctl branches delete test-migration-123
+```
+
+## Manual Rollback
+
+See `migration-rollback.md` for the full procedure.
+
+Quick rollback (last migration only):
+
+```bash
+DATABASE_URL="<target-branch-url>" go run ./cmd/migrate down 1
+```


### PR DESCRIPTION
Closes #166

## Summary

- Added `migrate` (prod) and `migrate-preview` (PR) jobs to
  `.github/workflows/ci.yml`
- Created `docs/ops/neon-branch-management.md`
- Created `docs/ops/migration-rollback.md`

## CI Jobs

| Job | Trigger | DB Secret | Gate |
|-----|---------|-----------|------|
| `migrate` | push to main | `NEON_PROD_URL` | `needs: [go-test]` |
| `migrate-preview` | pull_request | `NEON_PREVIEW_URL` | `needs: [go-test]` |

Both run `go run ./cmd/migrate up` from `apps/server/`.

## Dependency: #164

The `cmd/migrate` command doesn't exist yet — it's being built in #164
(BE task, still open). The migrate jobs will fail until #164 lands.
This is expected and documented in the commit message. Recommend
merging this PR first (CI jobs are additive, existing jobs unaffected),
then #164 will make them functional.

The `migrate-preview` job will fail on this PR's CI run for the same
reason — `cmd/migrate` doesn't exist on main yet.

## Docs

- `docs/ops/neon-branch-management.md`: 3 branches (main/preview/dev),
  reset procedure, fork-for-testing workflow, quick rollback reference
- `docs/ops/migration-rollback.md`: when to use down.sql vs manual
  intervention, 4-step prod rollback (pause → down → verify → resume),
  dirty-state recovery, notification contacts

Implemented by agent `ops-20260415-1506114`.