### PR TITLE
[be-20260414-1014081] pgx repository impl — swap in-memory stubs → Neon Postgres

### DIFF
--- a/apps/server/cmd/api/main.go
+++ b/apps/server/cmd/api/main.go
@@ -19,8 +19,9 @@ import (
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/db"
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/health"
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/otel"
+	pgxrepo "github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/repo/pgx"
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/router"
-	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/store"
+	memrepo "github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/repo/memory"
 )
 
 func main() {
@@ -56,34 +57,37 @@ func run() error {
 	// reports {"db":"not_configured"} instead of crashing startup —
 	// this lets Vercel previews boot before OPS wires the Neon URL.
 	var conn health.Pinger
+	deps := router.Deps{CookieSec: envDefault("COOKIE_SECURE", "") != ""}
+
 	if dbURL := os.Getenv("DATABASE_URL"); dbURL != "" {
-		d, err := db.Open(dbURL)
+		pool, err := db.OpenPool(context.Background(), dbURL)
 		if err != nil {
 			return err
 		}
-		defer d.Close()
-		conn = d
-		slog.Info("database connected")
+		defer pool.Close()
+		conn = &db.PoolPinger{Pool: pool}
+		deps.Users = pgxrepo.NewUserRepo(pool)
+		deps.AuditRepo = pgxrepo.NewAuditRepo(pool)
+		slog.Info("database connected (pgxpool)")
 	} else {
-		slog.Warn("DATABASE_URL not set — /api/health will report not_configured")
+		slog.Warn("DATABASE_URL not set — using memory repos")
+		users, err := memrepo.NewUserRepo()
+		if err != nil {
+			return err
+		}
+		deps.Users = users
 	}
+	deps.DB = conn
+	deps.Blacklist = blacklist.NewMemory()
 
-	// Auth deps — gracefully degrade when JWT keys aren't provided so local
-	// dev can iterate on non-auth endpoints without generating a keypair.
-	deps := router.Deps{DB: conn, CookieSec: envDefault("COOKIE_SECURE", "") != ""}
+	// Auth deps — gracefully degrade when JWT keys aren't provided.
 	if priv, pub := os.Getenv("JWT_PRIVATE_KEY"), os.Getenv("JWT_PUBLIC_KEY"); priv != "" && pub != "" {
 		kp, err := auth.LoadKeyPair(priv, pub)
 		if err != nil {
 			return err
 		}
-		users, err := store.NewMemoryUserRepo()
-		if err != nil {
-			return err
-		}
 		deps.KP = kp
-		deps.Users = users
-		deps.Blacklist = blacklist.NewMemory()
-		slog.Info("auth endpoints enabled", "seeded_users", 3)
+		slog.Info("auth endpoints enabled")
 	} else {
 		slog.Warn("JWT_PRIVATE_KEY/JWT_PUBLIC_KEY not set — /api/auth/* endpoints disabled")
 	}

--- a/apps/server/internal/authapi/handlers.go
+++ b/apps/server/internal/authapi/handlers.go
@@ -13,7 +13,7 @@ import (
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/blacklist"
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/httperr"
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/middleware"
-	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/store"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/repo"
 )
 
 // RefreshCookieName is the HttpOnly cookie carrying the refresh JWT.
@@ -25,7 +25,7 @@ func loginRateKey(ip, email string) string { return "login:" + ip + "|" + email 
 // Handlers wires the four auth endpoints against the stores provided.
 type Handlers struct {
 	KP        *auth.KeyPair
-	Users     store.UserRepo
+	Users     repo.UserRepo
 	Blacklist blacklist.Store
 	Limiter   *middleware.Limiter // per-IP + per-email login limiter
 	CookieSec bool                // set Secure flag on refresh cookie (false in local dev)
@@ -213,7 +213,7 @@ func (h *Handlers) me(w http.ResponseWriter, r *http.Request) {
 	}
 	u, err := h.Users.FindByID(r.Context(), c.Sub)
 	if err != nil {
-		if errors.Is(err, store.ErrUserNotFound) {
+		if errors.Is(err, repo.ErrNotFound) {
 			httperr.WriteFor(w, r, httperr.Unauthorized("user not found"))
 			return
 		}
@@ -257,7 +257,7 @@ func (h *Handlers) clearRefreshCookie(w http.ResponseWriter) {
 	})
 }
 
-func userOutOf(u *store.User) userOut {
+func userOutOf(u *repo.User) userOut {
 	return userOut{
 		ID: u.ID, Email: u.Email, Name: u.Name,
 		TenantID: u.TenantID, Roles: u.Roles, Permissions: u.Permissions,

--- a/apps/server/internal/authapi/handlers_test.go
+++ b/apps/server/internal/authapi/handlers_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/auth"
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/blacklist"
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/middleware"
-	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/store"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/repo/memory"
 )
 
 func setup(t *testing.T) (*Handlers, *chi.Mux, *auth.KeyPair) {
@@ -30,7 +30,7 @@ func setup(t *testing.T) (*Handlers, *chi.Mux, *auth.KeyPair) {
 	pub := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
 	kp, _ := auth.LoadKeyPair(priv, pub)
 
-	users, _ := store.NewMemoryUserRepo()
+	users, _ := memory.NewUserRepo()
 	h := &Handlers{
 		KP:        kp,
 		Users:     users,
@@ -135,7 +135,7 @@ func TestLogin_RateLimit_429(t *testing.T) {
 	priv := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}))
 	pub := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
 	kp, _ := auth.LoadKeyPair(priv, pub)
-	users, _ := store.NewMemoryUserRepo()
+	users, _ := memory.NewUserRepo()
 
 	h := &Handlers{
 		KP: kp, Users: users, Blacklist: blacklist.NewMemory(),
@@ -222,7 +222,7 @@ func TestRefresh_MissingCookie_401(t *testing.T) {
 
 func TestMe_HappyPath(t *testing.T) {
 	_, r, kp := setup(t)
-	c := auth.NewClaims("user-admin", "tenant-1", []string{"admin"}, store.PermsAdmin)
+	c := auth.NewClaims("user-admin", "tenant-1", []string{"admin"}, []string{"users:read", "users:write", "items:read", "items:write", "audit:read"})
 	tok, _ := kp.Sign(c)
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/me-authed", nil)
 	req.Header.Set("Authorization", "Bearer "+tok)
@@ -270,7 +270,7 @@ func TestMeHandler_AccessorReturnsFunction(t *testing.T) {
 
 func TestMe_UserDeletedBetweenLoginAndMe_401(t *testing.T) {
 	_, r, kp := setup(t)
-	c := auth.NewClaims("user-ghost", "tenant-1", []string{"admin"}, store.PermsAdmin)
+	c := auth.NewClaims("user-ghost", "tenant-1", []string{"admin"}, []string{"users:read", "users:write", "items:read", "items:write", "audit:read"})
 	tok, _ := kp.Sign(c)
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/me-authed", nil)
 	req.Header.Set("Authorization", "Bearer "+tok)

--- a/apps/server/internal/db/pool.go
+++ b/apps/server/internal/db/pool.go
@@ -1,0 +1,22 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// OpenPool returns a pgxpool.Pool connected to the Postgres instance at
+// dsn. Verifies connectivity via ping. The caller must defer pool.Close().
+func OpenPool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("pgxpool.New: %w", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("pool.Ping: %w", err)
+	}
+	return pool, nil
+}

--- a/apps/server/internal/db/poolpinger.go
+++ b/apps/server/internal/db/poolpinger.go
@@ -1,0 +1,15 @@
+package db
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PoolPinger wraps a pgxpool.Pool to satisfy the health.Pinger interface
+// which expects PingContext (not Ping).
+type PoolPinger struct{ Pool *pgxpool.Pool }
+
+func (p *PoolPinger) PingContext(ctx context.Context) error {
+	return p.Pool.Ping(ctx)
+}

--- a/apps/server/internal/repo/pgx/audit.go
+++ b/apps/server/internal/repo/pgx/audit.go
@@ -1,0 +1,38 @@
+package pgx
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/repo"
+)
+
+type AuditRepo struct{ pool *pgxpool.Pool }
+
+func NewAuditRepo(pool *pgxpool.Pool) *AuditRepo { return &AuditRepo{pool: pool} }
+
+// Write inserts an audit log entry. Errors are logged but never propagated
+// — the audit sink must not block the request.
+func (r *AuditRepo) Write(ctx context.Context, l *repo.AuditLog) error {
+	_, err := r.pool.Exec(ctx,
+		`INSERT INTO audit_logs (tenant_id, user_id, action, resource, ip, user_agent, trace_id, metadata, created_at)
+		 VALUES ($1, $2, $3, $4, $5::inet, $6, $7, $8, $9)`,
+		l.TenantID, nilIfEmpty(l.UserID), l.Action, l.Resource,
+		nilIfEmpty(l.IP), l.UserAgent, nilIfEmpty(l.TraceID),
+		l.Metadata, l.CreatedAt)
+	if err != nil {
+		slog.Warn("audit write failed — falling back to slog",
+			"error", err, "action", l.Action, "resource", l.Resource,
+			"user_id", l.UserID, "tenant_id", l.TenantID, "trace_id", l.TraceID)
+	}
+	return nil
+}
+
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/apps/server/internal/repo/pgx/items.go
+++ b/apps/server/internal/repo/pgx/items.go
@@ -1,0 +1,117 @@
+package pgx
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/repo"
+)
+
+type ItemRepo struct{ pool *pgxpool.Pool }
+
+func NewItemRepo(pool *pgxpool.Pool) *ItemRepo { return &ItemRepo{pool: pool} }
+
+func (r *ItemRepo) List(ctx context.Context, page, limit int) ([]*repo.Item, int, error) {
+	tid, err := tenantID(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > 100 {
+		limit = 20
+	}
+	offset := (page - 1) * limit
+
+	var total int
+	err = r.pool.QueryRow(ctx, `SELECT COUNT(*) FROM items WHERE tenant_id = $1`, tid).Scan(&total)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := r.pool.Query(ctx,
+		`SELECT id, tenant_id, title, description, created_at, updated_at
+		 FROM items WHERE tenant_id = $1
+		 ORDER BY created_at DESC
+		 LIMIT $2 OFFSET $3`, tid, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var items []*repo.Item
+	for rows.Next() {
+		it := &repo.Item{}
+		if err := rows.Scan(&it.ID, &it.TenantID, &it.Name, &it.Description, &it.CreatedAt, &it.UpdatedAt); err != nil {
+			return nil, 0, err
+		}
+		items = append(items, it)
+	}
+	if items == nil {
+		items = []*repo.Item{}
+	}
+	return items, total, rows.Err()
+}
+
+func (r *ItemRepo) Get(ctx context.Context, id string) (*repo.Item, error) {
+	tid, err := tenantID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	it := &repo.Item{}
+	err = r.pool.QueryRow(ctx,
+		`SELECT id, tenant_id, title, description, created_at, updated_at
+		 FROM items WHERE id = $1 AND tenant_id = $2`, id, tid).
+		Scan(&it.ID, &it.TenantID, &it.Name, &it.Description, &it.CreatedAt, &it.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, repo.ErrNotFound
+	}
+	return it, err
+}
+
+func (r *ItemRepo) Create(ctx context.Context, i *repo.Item) error {
+	tid, err := tenantID(ctx)
+	if err != nil {
+		return err
+	}
+	return r.pool.QueryRow(ctx,
+		`INSERT INTO items (tenant_id, title, description) VALUES ($1, $2, $3) RETURNING id, created_at, updated_at`,
+		tid, i.Name, i.Description).Scan(&i.ID, &i.CreatedAt, &i.UpdatedAt)
+}
+
+func (r *ItemRepo) Update(ctx context.Context, i *repo.Item) error {
+	tid, err := tenantID(ctx)
+	if err != nil {
+		return err
+	}
+	tag, err := r.pool.Exec(ctx,
+		`UPDATE items SET title = $1, description = $2, updated_at = $3 WHERE id = $4 AND tenant_id = $5`,
+		i.Name, i.Description, time.Now(), i.ID, tid)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return repo.ErrNotFound
+	}
+	return nil
+}
+
+func (r *ItemRepo) Delete(ctx context.Context, id string) error {
+	tid, err := tenantID(ctx)
+	if err != nil {
+		return err
+	}
+	tag, err := r.pool.Exec(ctx, `DELETE FROM items WHERE id = $1 AND tenant_id = $2`, id, tid)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return repo.ErrNotFound
+	}
+	return nil
+}

--- a/apps/server/internal/repo/pgx/tenants.go
+++ b/apps/server/internal/repo/pgx/tenants.go
@@ -1,0 +1,30 @@
+package pgx
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/repo"
+)
+
+type TenantRepo struct{ pool *pgxpool.Pool }
+
+func NewTenantRepo(pool *pgxpool.Pool) *TenantRepo { return &TenantRepo{pool: pool} }
+
+func (r *TenantRepo) Current(ctx context.Context) (*repo.Tenant, error) {
+	tid, err := tenantID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	t := &repo.Tenant{}
+	err = r.pool.QueryRow(ctx,
+		`SELECT id, name, slug, created_at, updated_at FROM tenants WHERE id = $1`, tid).
+		Scan(&t.ID, &t.Name, &t.Slug, &t.CreatedAt, &t.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, repo.ErrNotFound
+	}
+	return t, err
+}

--- a/apps/server/internal/repo/pgx/users.go
+++ b/apps/server/internal/repo/pgx/users.go
@@ -1,0 +1,95 @@
+// Package pgx implements the repo.* interfaces against Neon Postgres via
+// pgxpool.
+package pgx
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/middleware"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/repo"
+)
+
+type UserRepo struct{ pool *pgxpool.Pool }
+
+func NewUserRepo(pool *pgxpool.Pool) *UserRepo { return &UserRepo{pool: pool} }
+
+func (r *UserRepo) FindByEmail(ctx context.Context, email string) (*repo.User, error) {
+	tid, err := tenantID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	row := r.pool.QueryRow(ctx,
+		`SELECT u.id, u.tenant_id, u.email, u.name, u.password_hash, u.created_at, u.updated_at,
+		        array_agg(DISTINCT rl.name) FILTER (WHERE rl.name IS NOT NULL) AS roles,
+		        array_agg(DISTINCT p.key) FILTER (WHERE p.key IS NOT NULL) AS permissions
+		 FROM users u
+		 LEFT JOIN user_roles ur ON ur.user_id = u.id
+		 LEFT JOIN roles rl ON rl.id = ur.role_id
+		 LEFT JOIN role_permissions rp ON rp.role_id = rl.id
+		 LEFT JOIN permissions p ON p.id = rp.permission_id
+		 WHERE u.tenant_id = $1 AND u.email = $2
+		 GROUP BY u.id`, tid, email)
+	return scanUser(row)
+}
+
+func (r *UserRepo) FindByID(ctx context.Context, id string) (*repo.User, error) {
+	tid, err := tenantID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	row := r.pool.QueryRow(ctx,
+		`SELECT u.id, u.tenant_id, u.email, u.name, u.password_hash, u.created_at, u.updated_at,
+		        array_agg(DISTINCT rl.name) FILTER (WHERE rl.name IS NOT NULL) AS roles,
+		        array_agg(DISTINCT p.key) FILTER (WHERE p.key IS NOT NULL) AS permissions
+		 FROM users u
+		 LEFT JOIN user_roles ur ON ur.user_id = u.id
+		 LEFT JOIN roles rl ON rl.id = ur.role_id
+		 LEFT JOIN role_permissions rp ON rp.role_id = rl.id
+		 LEFT JOIN permissions p ON p.id = rp.permission_id
+		 WHERE u.id = $1 AND u.tenant_id = $2
+		 GROUP BY u.id`, id, tid)
+	return scanUser(row)
+}
+
+func (r *UserRepo) Create(ctx context.Context, u *repo.User) error {
+	tid, err := tenantID(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = r.pool.Exec(ctx,
+		`INSERT INTO users (tenant_id, email, name, password_hash) VALUES ($1, $2, $3, $4)`,
+		tid, u.Email, u.Name, string(u.PasswordHash))
+	return err
+}
+
+func scanUser(row pgx.Row) (*repo.User, error) {
+	var u repo.User
+	var hash string
+	err := row.Scan(&u.ID, &u.TenantID, &u.Email, &u.Name, &hash, &u.CreatedAt, &u.UpdatedAt, &u.Roles, &u.Permissions)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, repo.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	u.PasswordHash = []byte(hash)
+	if u.Roles == nil {
+		u.Roles = []string{}
+	}
+	if u.Permissions == nil {
+		u.Permissions = []string{}
+	}
+	return &u, nil
+}
+
+func tenantID(ctx context.Context) (string, error) {
+	tid, ok := middleware.TenantIDFromContext(ctx)
+	if !ok {
+		return "", repo.ErrMissingTenant
+	}
+	return tid, nil
+}

--- a/apps/server/internal/router/router.go
+++ b/apps/server/internal/router/router.go
@@ -15,7 +15,7 @@ import (
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/health"
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/middleware"
 	otelmw "github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/otel"
-	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/store"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/repo"
 )
 
 // Deps bundles the cross-cutting singletons the router needs.
@@ -24,9 +24,10 @@ import (
 type Deps struct {
 	DB        health.Pinger
 	KP        *auth.KeyPair
-	Users     store.UserRepo
+	Users     repo.UserRepo
 	Blacklist blacklist.Store
-	CookieSec bool // Secure cookie flag — true in prod, false in local http
+	AuditRepo repo.AuditRepo
+	CookieSec bool
 }
 
 // New returns a chi.Mux wired with the request-logging middleware and the
@@ -43,7 +44,9 @@ func NewWithDeps(d Deps) *chi.Mux {
 
 	r.Use(otelmw.Middleware) // OpenTelemetry span + W3C traceparent propagation
 	r.Use(loggingMiddleware)
-	// TODO(#N_AUDIT): r.Use(audit.Middleware)   — audit log capture
+	if d.AuditRepo != nil {
+		r.Use(middleware.Audit(d.AuditRepo))
+	}
 
 	// /api/health is intentionally NOT behind auth middleware —
 	// external probes (Vercel, uptime monitors) must reach it.

--- a/apps/server/internal/router/router_test.go
+++ b/apps/server/internal/router/router_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/auth"
 	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/blacklist"
-	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/store"
+	"github.com/liyoclaw1242/whitelabel-admin/apps/server/internal/repo/memory"
 )
 
 type stubPinger struct{ err error }
@@ -65,7 +65,7 @@ func TestNewWithDeps_MountsAuthEndpoints(t *testing.T) {
 	priv := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}))
 	pub := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
 	kp, _ := auth.LoadKeyPair(priv, pub)
-	users, _ := store.NewMemoryUserRepo()
+	users, _ := memory.NewUserRepo()
 
 	r := NewWithDeps(Deps{
 		DB:        &stubPinger{err: nil},


### PR DESCRIPTION
Closes #165.

Implemented by agent `be-20260414-1014081`.

## Changes

### New
- `internal/repo/pgx/{users,items,tenants,audit}.go` — 4 pgx impls of the Phase 3 repo interfaces. All queries parameterized (`$1`). Tenant isolation via `WHERE tenant_id = $X` on every query. `AuditRepo.Write` is non-blocking (slog.Warn on error, returns nil).
- `internal/db/pool.go` — `OpenPool(ctx, dsn) (*pgxpool.Pool, error)` with ping verification.
- `internal/db/poolpinger.go` — `PoolPinger` wraps `pgxpool.Pool.Ping(ctx)` → `PingContext(ctx)` for `health.Pinger` interface.

### Migration
- `authapi` + `router` migrated from `store.UserRepo` / `store.User` → `repo.UserRepo` / `repo.User`. This unifies the type system so both pgx and memory impls satisfy the same interface.
- `cmd/api/main.go`: when `DATABASE_URL` is set, uses `db.OpenPool` + pgx repos; otherwise falls back to `repo/memory` (Phase 3 dev mode preserved).
- Router `Deps.AuditRepo` wired → audit middleware enabled when repo is provided.

## Validation
- `go vet` + `go build` clean
- `go test -race -count=1 ./...` all green (all existing 13 packages pass after the `store → repo` type migration)
- Live Neon test deferred to CI (needs `DATABASE_URL` from preview branch secrets)