### PR TITLE
[ops-20260415-1506114] OPS: Env isolation docs, secret management, .env.local.example

### DIFF
--- a/apps/dashboard/.env.local.example
+++ b/apps/dashboard/.env.local.example
@@ -1,0 +1,40 @@
+# Local development environment — copy to .env.local and fill in values.
+# All variables are optional locally; the app starts with graceful fallbacks.
+
+# --- Mock API (set to "1" to bypass real backend) ---
+NEXT_PUBLIC_USE_MOCK_API=1
+
+# --- Database (Neon dev branch) ---
+DATABASE_URL=
+
+# --- Backend proxy (only needed when running Go server locally) ---
+# BACKEND_URL=http://localhost:8080
+
+# --- JWT (dev keypair — generate with: cd apps/server && go run ./cmd/keygen) ---
+JWT_PRIVATE_KEY=
+JWT_PUBLIC_KEY=
+
+# --- Cloudflare Workers KV (dev namespace) ---
+CF_API_TOKEN=
+CF_ACCOUNT_ID=
+CF_KV_NAMESPACE_ID=
+
+# --- Resend (transactional email) ---
+RESEND_API_KEY=
+
+# --- OpenTelemetry (leave blank to disable tracing locally) ---
+OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_EXPORTER_OTLP_HEADERS=
+
+# --- Grafana Faro (leave blank to disable frontend RUM locally) ---
+GRAFANA_FARO_URL=
+GRAFANA_FARO_APP_KEY=
+NEXT_PUBLIC_GRAFANA_FARO_URL=
+NEXT_PUBLIC_GRAFANA_FARO_APP_KEY=
+
+# --- Sentry (leave blank to disable error tracking locally) ---
+SENTRY_DSN=
+NEXT_PUBLIC_SENTRY_DSN=
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=

--- a/docs/ops/neon-branch-per-pr.md
+++ b/docs/ops/neon-branch-per-pr.md
@@ -1,0 +1,57 @@
+# Neon Branch-per-PR Strategy
+
+## Chosen Approach: Option A — Neon GitHub Integration
+
+The Neon GitHub integration auto-creates a database branch for each PR and cleans up on merge/close. This is the recommended approach for preview isolation.
+
+## Current State
+
+Currently using a **shared preview branch** for all PRs:
+- `NEON_PREVIEW_URL` points to a single `preview` Neon branch
+- All PRs share the same preview database
+
+## Enabling Branch-per-PR
+
+### Prerequisites
+
+1. Install the [Neon GitHub Integration](https://neon.tech/docs/guides/neon-github-integration)
+2. Connect to the `whitelabel-admin` repo
+3. Configure branch creation rules
+
+### Setup Steps
+
+1. In Neon dashboard: Settings → Integrations → GitHub → Connect
+2. Select the `liyoclaw1242/whitelabel-admin` repo
+3. Configure:
+   - Create branch on: PR opened
+   - Delete branch on: PR merged or closed
+   - Parent branch: `main`
+
+### CI Changes Needed
+
+Once enabled, update `migrate-preview` in `.github/workflows/ci.yml`:
+
+```yaml
+migrate-preview:
+  steps:
+    - run: go run ./cmd/migrate up
+      env:
+        DATABASE_URL: ${{ secrets.NEON_PREVIEW_URL_PR_${{ github.event.pull_request.number }} }}
+```
+
+Or use the Neon integration's automatic env injection if supported.
+
+### Cleanup
+
+The Neon integration handles cleanup automatically when PRs are merged or closed. No manual intervention needed.
+
+## Environment Isolation Matrix
+
+| Env | Neon Branch | JWT Keys | Grafana Stack | Faro Endpoint |
+|-----|-------------|----------|---------------|---------------|
+| Development | `dev` | dev-keypair | shared dev | dev collect URL |
+| Preview (current) | `preview` (shared) | preview-keypair | shared dev | dev collect URL |
+| Preview (future) | `pr-{N}` fork from main | preview-keypair | shared dev | dev collect URL |
+| Production | `main` | prod-keypair | prod | prod collect URL |
+
+Each environment's JWT keypair MUST be independent. Never share private keys across environments.

--- a/docs/ops/secret-inventory.md
+++ b/docs/ops/secret-inventory.md
@@ -1,0 +1,47 @@
+# Secret Inventory
+
+Last updated: 2026-04-17 by `ops-20260415-1506114`
+
+## Vercel Environment Variables
+
+| Variable | Dev | Preview | Prod | Source | Notes |
+|----------|-----|---------|------|--------|-------|
+| `DATABASE_URL` | Yes | Yes | Yes | Neon (#138) | Pooled connection per branch |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes | Yes | Yes | Grafana Cloud (#138) | Tempo OTLP HTTP ingest |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Yes | Yes | Yes | Grafana Cloud (#138) | Basic auth header |
+| `GRAFANA_FARO_URL` | Yes | Yes | Yes | Grafana Cloud (#138) | Faro collect endpoint |
+| `GRAFANA_FARO_APP_KEY` | Yes | Yes | Yes | Grafana Cloud (#138) | Faro app identifier |
+| `NEXT_PUBLIC_GRAFANA_FARO_URL` | Yes | Yes | Yes | Grafana Cloud (#138) | Client-side Faro URL |
+| `NEXT_PUBLIC_GRAFANA_FARO_APP_KEY` | Yes | Yes | Yes | Grafana Cloud (#138) | Client-side Faro key |
+| `CF_API_TOKEN` | Yes | Yes | Yes | Cloudflare (#138) | Workers KV Storage: Edit |
+| `CF_ACCOUNT_ID` | Yes | Yes | Yes | Cloudflare (#138) | Account identifier |
+| `CF_KV_NAMESPACE_ID` | Yes | Yes | Yes | Cloudflare (#138) | KV namespace for refresh blacklist |
+| `NEXT_PUBLIC_USE_MOCK_API` | No | No | Yes | OPS (#162) | Temporary — remove when real API live |
+
+### Not Yet Set
+
+| Variable | Reason | Blocker |
+|----------|--------|---------|
+| `JWT_PRIVATE_KEY` | Per-env RS256 private key | BE keygen tool needed |
+| `JWT_PUBLIC_KEY` | Per-env RS256 public key | BE keygen tool needed |
+| `RESEND_API_KEY` | Transactional email | Resend account (#138) |
+
+## GitHub Actions Secrets
+
+| Secret | Purpose | Set By |
+|--------|---------|--------|
+| `NEON_PROD_URL` | Production Neon connection | User (#138) |
+| `NEON_PREVIEW_URL` | Preview Neon connection | User (#138) |
+| `NEON_DEV_URL` | Dev Neon connection | User (#138) |
+
+### Not Yet Set
+
+| Secret | Purpose |
+|--------|---------|
+| `VERCEL_TOKEN` | Vercel CLI deploy in release.yml |
+| `VERCEL_ORG_ID` | Vercel org for release.yml |
+| `VERCEL_PROJECT_ID` | Vercel project for release.yml |
+
+## Local Development
+
+See `apps/dashboard/.env.local.example` for the complete variable list with defaults.

--- a/docs/ops/secret-rotation.md
+++ b/docs/ops/secret-rotation.md
@@ -1,0 +1,62 @@
+# Secret Rotation
+
+## Rotation Schedule
+
+| Secret | Rotation Period | Reason |
+|--------|----------------|--------|
+| `JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY` | 90 days | RS256 keypair — compromise window mitigation |
+| `CF_API_TOKEN` | 180 days | Cloudflare API token — limited blast radius (KV only) |
+| `RESEND_API_KEY` | 180 days | Email sending — low risk, rotate on schedule |
+| `DATABASE_URL` | On compromise only | Neon connection string — rotate password via Neon dashboard |
+| `OTEL_EXPORTER_OTLP_HEADERS` | On compromise only | Grafana ingest auth — low risk (write-only) |
+| `GRAFANA_FARO_APP_KEY` | On compromise only | Faro app key — public by design (client-side) |
+| `VERCEL_TOKEN` | 180 days | Vercel deploy token — high privilege |
+
+## JWT Key Rotation Procedure
+
+### 1. Generate New Keypair
+
+```bash
+cd apps/server
+go run ./cmd/keygen
+```
+
+### 2. Update Vercel Env (per environment)
+
+```bash
+vercel env rm JWT_PRIVATE_KEY production --yes
+vercel env rm JWT_PUBLIC_KEY production --yes
+printf '%s' "$(cat private.pem)" | vercel env add JWT_PRIVATE_KEY production
+printf '%s' "$(cat public.pem)" | vercel env add JWT_PUBLIC_KEY production
+```
+
+Repeat for preview and development.
+
+### 3. Redeploy
+
+```bash
+vercel redeploy <latest-deployment-url>
+```
+
+### 4. Verify
+
+Existing sessions using the old public key will fail validation. Users will need to re-login. This is expected and acceptable for a 90-day rotation.
+
+## Cloudflare API Token Rotation
+
+1. Cloudflare dashboard → My Profile → API Tokens
+2. Create new token with same permissions (Account > Workers KV Storage > Edit)
+3. Update Vercel env: `vercel env rm CF_API_TOKEN production --yes && printf '<new-token>' | vercel env add CF_API_TOKEN production`
+4. Repeat for preview/development
+5. Redeploy
+6. Delete old token in Cloudflare dashboard
+
+## Emergency Rotation (Compromise)
+
+If a secret is compromised:
+
+1. **Immediately** rotate the affected secret using the steps above
+2. Redeploy all environments
+3. If JWT keys compromised: all active sessions are invalidated (users re-login)
+4. If DATABASE_URL compromised: reset password in Neon dashboard, update all environments
+5. Document the incident in a GitHub issue


### PR DESCRIPTION
Closes #185

## Summary

### 1. Neon Branch-per-PR Strategy
Documented in `docs/ops/neon-branch-per-pr.md`:
- Chosen approach: Neon GitHub Integration (auto-fork per PR)
- Current state: shared `preview` branch
- Setup steps + CI changes needed to enable
- Environment isolation matrix (dev/preview/prod)

### 2. Secret Inventory
`docs/ops/secret-inventory.md`:
- Full audit of all 31 Vercel env vars across 3 environments
- GitHub Actions secrets (NEON_*_URL)
- Not-yet-set vars (JWT keys, RESEND, VERCEL deploy tokens)

### 3. Secret Rotation
`docs/ops/secret-rotation.md`:
- Rotation schedule: JWT 90d, CF/Resend/Vercel 180d, DB on-compromise
- Step-by-step JWT rotation procedure
- Cloudflare token rotation procedure
- Emergency rotation playbook

### 4. `.env.local.example`
`apps/dashboard/.env.local.example`:
- Complete variable list for local dev onboarding
- Mock API enabled by default (`NEXT_PUBLIC_USE_MOCK_API=1`)
- All external service vars optional with graceful fallbacks

### Git History Audit
Verified `git log --all -p | grep -iE "(private_key|api_key|password)"`:
only test fixtures (mock login `password`) and placeholder references.
No real secrets in git history.

### JWT Independence
JWT env vars (`JWT_PRIVATE_KEY`, `JWT_PUBLIC_KEY`) are not yet set in
Vercel — documented as pending in secret-inventory.md. When set, each
environment MUST use independent keypairs (documented in rotation +
branch-per-PR docs).

Implemented by agent `ops-20260415-1506114`.