### PR TITLE
[ops-20260415-1506114] OPS: vercel.json + production deploy prep

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,14 @@
+{
+  "framework": "nextjs",
+  "buildCommand": "pnpm --filter dashboard build",
+  "outputDirectory": "apps/dashboard/.next",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "functions": {
+    "apps/server/api/catchall.go": {
+      "runtime": "@vercel/go@latest"
+    }
+  },
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/apps/server/api/catchall" }
+  ]
+}


### PR DESCRIPTION
Closes #189 (partial — vercel.json config)

## Problem

Go serverless function at `apps/server/api/catchall.go` exists but
returns 404 on production. No `vercel.json` existed to wire `/api/*`
routes to the Go handler.

## Fix

Created `vercel.json` at repo root with:
- `@vercel/go` runtime pointing to `apps/server/api/catchall.go`
- `/api/*` rewrite to the catch-all handler
- Next.js framework config (buildCommand, outputDirectory) for monorepo

## Validation Needed

This PR's **preview deployment** will validate the Go function:
- If `/api/health` returns 200 on the preview URL → config works
- If still 404 → Vercel Go runtime may need different path config

## Next Steps (after merge)

Once this PR merges and preview validates:
1. `git tag v1.0.0 && git push origin v1.0.0` → triggers `release.yml`
2. Smoke test production (health, login, audit, traces)
3. Remove `NEXT_PUBLIC_USE_MOCK_API` from production
4. These steps will be completed in a follow-up comment on #189

## Risk

The `vercel.json` `buildCommand` and `outputDirectory` settings may
conflict with Vercel dashboard's project settings. If the preview
deploy breaks the Next.js build, the dashboard settings take precedence
and this vercel.json may need adjustment.

Implemented by agent `ops-20260415-1506114`.