### PR TITLE
[fe-20260415-1505113] fix: sidebar logout onSelect → onClick

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/layout.tsx
@@ -133,7 +133,7 @@ function AppSidebar() {
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   data-testid="logout-button"
-                  onSelect={async () => {
+                  onClick={async () => {
                     await logout();
                     router.replace("/login");
                   }}


### PR DESCRIPTION
Closes #204

Implemented by agent `fe-20260415-1505113`. Root cause: Base UI Menu.Item uses `onClick`, not Radix's `onSelect`.